### PR TITLE
Step last success

### DIFF
--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -28,6 +28,7 @@ executable backend
                    Handlers.Statuses,
                    Handlers.Steps,
                    Handlers.StepConfig,
+                   Handlers.StepLastSuccess,
                    Handlers.RunStep,
                    Handlers.StatusStream,
                    Handlers.Upload,

--- a/backend/src/Handlers/StepLastSuccess.hs
+++ b/backend/src/Handlers/StepLastSuccess.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Handlers.StepLastSuccess (getStepLastSuccessesHandler, StepLastSuccess (..)) where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (ToJSON)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text, pack, unpack)
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
+import GHC.Generics (Generic)
+import OutPaths (getProjectOutPaths)
+import ProcessLimiter (readProcessWithExitCodeL)
+import Servant (Handler, err500, errBody, throwError)
+import System.Exit (ExitCode (..))
+import UserRepo (ReadRepoContext (..), runGitIn, withReadRepoTransaction)
+
+data StepLastSuccess = StepLastSuccess
+    { commit :: Text
+    , outPath :: Text
+    }
+    deriving (Generic, ToJSON)
+
+getStepLastSuccessesHandler :: Int -> Int -> Maybe Text -> Handler [StepLastSuccess]
+getStepLastSuccessesHandler sid pid mCommit = do
+    result <- liftIO $ withReadRepoTransaction $ \(ReadRepoContext repoPath commitHash) -> do
+        let startCommit = maybe commitHash unpack mCommit
+        liftIO $ findAllSuccesses repoPath pid sid startCommit
+    case result of
+        Left err -> throwError err500{errBody = TLE.encodeUtf8 (TL.pack err)}
+        Right found -> return found
+
+findAllSuccesses :: FilePath -> Int -> Int -> String -> IO [StepLastSuccess]
+findAllSuccesses repoPath pid sid startCommit = do
+    (ec, out, _) <-
+        runGitIn repoPath ["log", "--pretty=%H", startCommit, "--", "steps/*.nix", "templates/*.nix"]
+    case ec of
+        ExitFailure _ -> return []
+        ExitSuccess -> walk (lines out) [] Set.empty
+  where
+    walk :: [String] -> [StepLastSuccess] -> Set Text -> IO [StepLastSuccess]
+    walk [] acc _ = return (reverse acc)
+    walk (c : cs) acc seen = do
+        outPaths <- getProjectOutPaths pid (pack c)
+        case Map.lookup sid outPaths of
+            Nothing -> walk cs acc seen
+            Just p
+                | Set.member p seen -> walk cs acc seen
+                | otherwise -> do
+                    built <- isBuilt (unpack p)
+                    let seen' = Set.insert p seen
+                    if built
+                        then walk cs (StepLastSuccess (pack c) p : acc) seen'
+                        else walk cs acc seen'
+
+isBuilt :: FilePath -> IO Bool
+isBuilt p = do
+    (ec, _, _) <- readProcessWithExitCodeL "nix" ["path-info", p] ""
+    return $ ec == ExitSuccess

--- a/backend/src/Main.hs
+++ b/backend/src/Main.hs
@@ -21,6 +21,7 @@ import Handlers.SrcFiles (UserRepoInfo, downloadSrcFilesHandler, getUserRepoInfo
 import Handlers.StatusStream (EventStream, stepStatusStreamHandler)
 import Handlers.Statuses (getProjectOutPathsHandler)
 import Handlers.StepConfig (getStepConfigHandler)
+import Handlers.StepLastSuccess (StepLastSuccess, getStepLastSuccessesHandler)
 import Handlers.Steps (patchStepHandler, postStepHandler)
 import Handlers.Store (DirEntry, downloadHandler, listHandler, storeFilesHandler)
 import Handlers.Upload (uploadHandler)
@@ -53,6 +54,7 @@ type API =
         :<|> "project-entities" :> "batch" :> QueryParam' '[Required, Strict] "project_id" Int :> ReqBody '[JSON] [Int] :> Post '[JSON] NoContent
         :<|> "project-entities" :> QueryParam' '[Required, Strict] "project_id" Int :> QueryParam' '[Required, Strict] "entity_id" Int :> Delete '[JSON] NoContent
         :<|> "project-out-paths" :> QueryParam' '[Required, Strict] "id" Int :> QueryParam "commit" Text :> Get '[JSON] (Map Int Text)
+        :<|> "step-last-successes" :> QueryParam' '[Required, Strict] "id" Int :> QueryParam' '[Required, Strict] "project_id" Int :> QueryParam "commit" Text :> Get '[JSON] [StepLastSuccess]
         :<|> "step-status-stream" :> QueryParam' '[Required, Strict] "project_id" Int :> QueryParam "commit" Text :> StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
         :<|> "step-config" :> QueryParam "commit" Text :> Get '[RawJSON] LBS.ByteString
         :<|> "step" :> QueryParam' '[Required, Strict] "id" Int :> ReqBody '[RawJSON] LBS.ByteString :> Patch '[JSON] NoContent
@@ -79,6 +81,7 @@ server =
         :<|> batchAssignRecordsHandler
         :<|> unassignRecordHandler
         :<|> getProjectOutPathsHandler
+        :<|> getStepLastSuccessesHandler
         :<|> stepStatusStreamHandler
         :<|> getStepConfigHandler
         :<|> patchStepHandler
@@ -160,6 +163,13 @@ corsPolicy req = case pathInfo req of
                 , corsOrigins = Nothing
                 }
     ["project-out-paths"] ->
+        Just $
+            simpleCorsResourcePolicy
+                { corsRequestHeaders = ["Content-Type"]
+                , corsMethods = ["GET", "OPTIONS"]
+                , corsOrigins = Nothing
+                }
+    ["step-last-successes"] ->
         Just $
             simpleCorsResourcePolicy
                 { corsRequestHeaders = ["Content-Type"]

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -24,6 +24,7 @@ import List.Extra as List
 import Maybe.Extra as Maybe
 import Model.Core as Model exposing (AddMode(..), BaseRecord, Model, ProjectRecord, Status(..), StepRecord, StepStatusEvent(..), Table, TableTag(..), dndSystem)
 import Model.Lenses exposing (..)
+import Model.Core as Model
 import Model.Lib exposing (sortProjects)
 import Model.TableSpec as TableSpec exposing (StepSpec, TableSpec, getTag)
 import Ports
@@ -477,6 +478,43 @@ runStep spec id =
         |> FlowError.foldResult
             (\_ -> Flow.pure ())
             (\_ -> setStatus (ApiData.loading <| Just (StatusFailure Nothing)))
+
+
+fetchLastSuccessesFor : Int -> Flow Model ()
+fetchLastSuccessesFor stepId =
+    Flow.forAll currentProjectId
+        (\projectId ->
+            Flow.get
+                |> Flow.andThen
+                    (\model ->
+                        case Dict.get stepId (Model.getLastSuccesses model) of
+                            Just (ApiData.Loading _) ->
+                                Flow.pure ()
+
+                            Just (ApiData.Success _) ->
+                                Flow.pure ()
+
+                            _ ->
+                                let
+                                    mCommit_ =
+                                        try (route << Route.project << mCommit << just) model
+                                in
+                                Flow.over lastSuccesses (Dict.insert stepId (ApiData.loading Nothing))
+                                    |> Flow.seq (Api.fetchStepLastSuccesses projectId stepId mCommit_)
+                                    |> Flow.andThen
+                                        (\result ->
+                                            Flow.over lastSuccesses (Dict.insert stepId (ApiData.fromResult result))
+                                        )
+                    )
+        )
+
+
+navigateToSuccessCommit : Int -> String -> Flow Model ()
+navigateToSuccessCommit stepId commit =
+    Flow.forAll currentProjectId
+        (\projectId ->
+            goToRoute (Project { projectId = projectId, mHighlight = Just { id = stepId, path = [] }, mCommit = Just commit })
+        )
 
 
 stopStep : StepSpec -> Int -> Flow Model ()

--- a/frontend/src/Api/Api.elm
+++ b/frontend/src/Api/Api.elm
@@ -11,6 +11,7 @@ module Api.Api exposing
     , fetchSrcDirectoryContents
     , fetchSrcFileContents
     , fetchStepConfig
+    , fetchStepLastSuccesses
     , fetchUserRepoInfo
     , runStep
     , saveProject
@@ -141,6 +142,18 @@ fetchStepConfig commit =
         Http.get
             { url = appendCommitQuery "/backend/step-config" commit
             , expect = Http.expectJson identity Decode.stepConfig
+            }
+
+
+fetchStepLastSuccesses : Int -> Int -> Maybe String -> Flow s (Result Http.Error (List { commit : String, outPath : String }))
+fetchStepLastSuccesses projectId stepId commit =
+    Flow.lift <|
+        Http.get
+            { url =
+                appendCommitQuery
+                    ("/backend/step-last-successes?id=" ++ String.fromInt stepId ++ "&project_id=" ++ String.fromInt projectId)
+                    commit
+            , expect = Http.expectJson identity (Json.Decode.list Decode.stepLastSuccess)
             }
 
 

--- a/frontend/src/Api/Decode.elm
+++ b/frontend/src/Api/Decode.elm
@@ -317,3 +317,10 @@ stepConfigEntry =
 stepConfig : Decoder StepConfig
 stepConfig =
     Decode.dict stepConfigEntry
+
+
+stepLastSuccess : Decoder { commit : String, outPath : String }
+stepLastSuccess =
+    Decode.succeed (\c op -> { commit = c, outPath = op })
+        |> required "commit" Decode.string
+        |> required "outPath" Decode.string

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -59,7 +59,7 @@ setRouteFromUrl url =
                 in
                 Flow.modify (set route newRoute)
                     |> Flow.seq
-                        (Flow.over (Model.Lenses.projects << Model.Lenses.records) Api.ApiData.toLoading
+                        (Flow.setAll (Model.Lenses.projects << Model.Lenses.records) Api.ApiData.NotAsked
                             |> Flow.seq Actions.loadStepConfig
                             |> Flow.seq Actions.loadProjects
                             |> Flow.when (mOldCommit /= mNewCommit)

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -110,6 +110,12 @@ type alias UserRepoInfo =
     }
 
 
+type alias LastSuccess =
+    { commit : String
+    , outPath : String
+    }
+
+
 type Model
     = Model
         { projects : Table ProjectRecord
@@ -127,6 +133,7 @@ type Model
         , userRepoInfo : ApiData UserRepoInfo
         , uploadProgress : Dict Int UploadProgress
         , stepStatusHooks : Dict Int (Flow Model ())
+        , lastSuccesses : Dict Int (ApiData (List LastSuccess))
         }
 
 
@@ -190,6 +197,11 @@ getStepStatusHooks (Model model) =
     model.stepStatusHooks
 
 
+getLastSuccesses : Model -> Dict Int (ApiData (List LastSuccess))
+getLastSuccesses (Model model) =
+    model.lastSuccesses
+
+
 dndSystem : DnDList.System a DnDList.Msg
 dndSystem =
     let
@@ -248,6 +260,7 @@ initialModel key route flags =
         , userRepoInfo = NotAsked
         , uploadProgress = Dict.empty
         , stepStatusHooks = Dict.empty
+        , lastSuccesses = Dict.empty
         }
 
 

--- a/frontend/src/Model/Lenses.elm
+++ b/frontend/src/Model/Lenses.elm
@@ -439,3 +439,8 @@ uploadProgress =
 stepStatusHooks : Lens ls Model (Dict Int (Flow Model ())) x y
 stepStatusHooks =
     lens ".stepStatusHooks" Model.getStepStatusHooks (\(Model m) hooks -> Model { m | stepStatusHooks = hooks })
+
+
+lastSuccesses : Lens ls Model (Dict Int (ApiData (List Model.LastSuccess))) x y
+lastSuccesses =
+    lens ".lastSuccesses" Model.getLastSuccesses (\(Model m) ls -> Model { m | lastSuccesses = ls })

--- a/frontend/src/View/Shadow.elm
+++ b/frontend/src/View/Shadow.elm
@@ -2,12 +2,14 @@ module View.Shadow exposing (viewProject)
 
 import Accessors exposing (has, just, try)
 import Actions
-import Api.ApiData as ApiData
+import Api.ApiData as ApiData exposing (ApiData(..))
 import Dict
 import Flow exposing (Flow)
 import Html exposing (Html)
-import Html.Attributes
+import Html.Attributes exposing (attribute, class, id, style, title)
+import Html.Events as Events
 import Html.Extra as Html
+import Json.Decode as Decode
 import Model.Core as Model exposing (Model, ProjectRecord, StepRecord, Table)
 import Model.Lenses exposing (mCommit, route)
 import Model.Shadow exposing (StepType(..))
@@ -15,9 +17,63 @@ import Model.TableSpec as TableSpec
 import Route
 import Specs
 import View.FileBrowser as FileBrowser
-import View.Icons exposing (iconCustom)
+import View.Icons exposing (icon, iconCustom)
 import View.Lib exposing (viewPage, viewSearchBox)
 import View.Table exposing (viewIconButtonWithTooltip, viewRunButton, viewStopButton, viewTable, viewUploadButton, viewUploadProgress)
+
+
+viewLastSuccessesPopover : Model -> Int -> Html (Flow Model ())
+viewLastSuccessesPopover model stepId =
+    let
+        popoverId =
+            "last-successes-popover-" ++ String.fromInt stepId
+
+        body =
+            case Dict.get stepId (Model.getLastSuccesses model) of
+                Just (Success []) ->
+                    [ Html.div [ class "last-successes-message" ] [ Html.text "No previous successful version" ] ]
+
+                Just (Success entries) ->
+                    List.map (viewLastSuccessEntry stepId) entries
+
+                Just (Error _) ->
+                    [ Html.div [ class "last-successes-message" ] [ Html.text "Failed to load history" ] ]
+
+                _ ->
+                    [ Html.div [ class "last-successes-message" ]
+                        [ Html.span [ class "shimmer-text", class "shimmer-text--medium-contrast" ] [ Html.text "Loading..." ] ]
+                    ]
+    in
+    Html.span []
+        [ Html.button
+            [ class "icon-btn"
+            , title "Find last successful version"
+            , attribute "popovertarget" popoverId
+            , style "anchor-name" ("--anchor-" ++ popoverId)
+            , Events.onClick (Actions.fetchLastSuccessesFor stepId)
+            ]
+            [ icon True "restore"
+            , Html.span [ class "icon-btn-text" ] [ Html.text "Find last successful version" ]
+            ]
+        , Html.div
+            [ class "last-successes-popover"
+            , id popoverId
+            , attribute "popover" "auto"
+            , style "position-anchor" ("--anchor-" ++ popoverId)
+            , Events.on "click" (Decode.succeed (Actions.hidePopover popoverId))
+            ]
+            body
+        ]
+
+
+viewLastSuccessEntry : Int -> Model.LastSuccess -> Html (Flow Model ())
+viewLastSuccessEntry stepId entry =
+    Html.button
+        [ class "last-successes-entry"
+        , title entry.commit
+        , Events.onClick (Actions.navigateToSuccessCommit stepId entry.commit)
+        ]
+        [ Html.text (String.left 8 entry.commit) ]
 
 
 viewProject : Model -> ProjectRecord -> Html (Flow Model ())
@@ -108,13 +164,18 @@ viewSection model sectionName stepType steps =
                                 case r.id of
                                     Just id ->
                                         let
+                                            mStatus =
+                                                TableSpec.getStatus spec r |> ApiData.toMaybe
+
                                             isRunning =
-                                                TableSpec.getStatus spec r
-                                                    |> ApiData.toMaybe
-                                                    |> (==) (Just Model.StatusRunning)
+                                                mStatus == Just Model.StatusRunning
+
+                                            isNotStarted =
+                                                mStatus == Just Model.StatusNotStarted
                                         in
                                         [ viewRunButton "Run" (Actions.runStep spec id)
                                         , Html.viewIf isRunning (viewStopButton "Stop" (Actions.stopStep spec id))
+                                        , Html.viewIf isNotStarted (viewLastSuccessesPopover model id)
                                         ]
 
                                     Nothing ->

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -275,6 +275,10 @@ body {
   }
 }
 
+.app:has(.last-successes-popover:popover-open) {
+  pointer-events: none;
+}
+
 .last-successes-popover {
   margin: 0;
   padding: 0;
@@ -299,6 +303,7 @@ body {
     min-width: 160px;
     max-height: 50vh;
     overflow-y: auto;
+    pointer-events: auto;
   }
 
   &::backdrop {

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -275,6 +275,55 @@ body {
   }
 }
 
+.last-successes-popover {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+
+  &:popover-open {
+    display: flex;
+    position: absolute;
+    position-area: bottom span-left;
+    position-try-fallbacks: top span-left, bottom span-right, top span-right;
+    margin: 0;
+    margin-top: var(--spacing-xs);
+    background-color: var(--bg-elevated);
+    border: 1px solid var(--color-gray-500);
+    padding: var(--spacing-sm);
+    flex-direction: column;
+    gap: var(--spacing-2xs);
+    box-shadow: var(--shadow-elevated);
+    border-radius: var(--radius-sm);
+    align-items: stretch;
+    min-width: 160px;
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
+  &::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+  }
+}
+
+.last-successes-entry {
+  @include mixins.button-base;
+  @include mixins.interactive-element;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  text-align: left;
+  font-family: monospace;
+  font-size: var(--font-size-sm);
+}
+
+.last-successes-message {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
 .record-name-container {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
add step last-success navigation
Backend: GET /step-last-successes?id&project_id&commit. git log --pretty=%H
<start> -- steps/*.nix templates/*.nix (pathspec filter, skips commits that
can't affect step outPath). Per commit: getProjectOutPaths (reuses existing
(pid,commit) cache), Map.lookup sid outPaths, dedupe via Set Text, isBuilt
= nix path-info. Returns [StepLastSuccess { commit, outPath }], newest-first.

Frontend: "restore" icon-btn renders on not-started derivation steps. Click
fires Actions.fetchLastSuccessesFor which populates Model.lastSuccesses : Dict
Int (ApiData (List LastSuccess)) — idempotent, skips if Loading/Success.
Native popover (popovertarget + anchor-name + position-anchor); dismiss via
bubbling Events.on "click" → hidePopover, same pattern as mobile
.table-record-actions. Body case-matches ApiData: Loading → shimmer-text
--medium-contrast placeholder; Success [] and Error → plain text messages;
Success list → .last-successes-entry buttons showing first 8 chars of commit,
full hash in title. Entry click → Actions.navigateToSuccessCommit → goToRoute
Project { projectId, mHighlight = Just { id = stepId, path = [] }, mCommit =
Just commit } — existing read-only view + banner.