### PR TITLE
cull dead scss: .select, .input-wrapper

### DIFF
--- a/frontend/styles/components/_select.scss
+++ b/frontend/styles/components/_select.scss
@@ -45,12 +45,6 @@
     }
 }
 
-.input-wrapper {
-    position: relative;
-    display: flex;
-    align-items: center;
-}
-
 .material-symbols-outlined.remove-selected-icon {
   cursor: pointer;
 }

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -689,26 +689,6 @@ $form-vertical-gap: var(--spacing-md);
   gap: var(--spacing-xs);
 }
 
-// Select components
-.select {
-  @include mixins.form-control;
-  @include mixins.button-base;
-
-  &:hover {
-    border-color: var(--text-primary);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-
-    &:hover {
-      border-color: var(--border-color);
-      background: var(--bg-elevated);
-    }
-  }
-}
-
 $readonly-disabled-targets: (
   "input.form-input",
   "textarea.file-content",


### PR DESCRIPTION
Both defined, never applied:
- .select: no <select> elements in markup. Custom Components/Select uses .select-container/.select-menu/.select-menu-item/#select-input.
- .input-wrapper: no markup uses it.