### PR TITLE
Render template and argument displayName + description in UI

### DIFF
--- a/docs/pages/type-reference.md
+++ b/docs/pages/type-reference.md
@@ -2,7 +2,16 @@
 
 This page documents the option types that template authors use inside `options.pointy.<name>`. They are available as `config._pointy.lib.types` inside a module, so templates typically open a `with config._pointy.lib.types;` block in their `options` section.
 
-Pointy serializes these types into `.#pointy.stepConfig`, which the frontend uses to decide which widgets to render. The current UI uses option names as field labels; `description` values are still carried through the schema, but they are not currently rendered as on-screen labels.
+Pointy serializes these types into `.#pointy.stepConfig`, which the frontend uses to decide which widgets to render.
+
+## User-facing labels and hints
+
+Two optional fields control what users see in the UI:
+
+- `displayName` — short label shown in table headings, modal titles, form labels, and the type chip in step selectors. When omitted, the raw attribute name is used.
+- `description` — longer help text shown as a hint under the field (for option types) or as an intro paragraph in the create/edit modal (for step type declarations).
+
+Both can be set on step type declarations (`pointy.type.derivation`, `pointy.type.fileUpload`) and on option types (`pointy.string`, `pointy.step`, indirectly on `pointy.listOf` via its inner type).
 
 ## Step type declarations
 
@@ -11,28 +20,34 @@ These are set at the top level of a template file, outside `module`, to tell Poi
 ### `pointy.type.derivation`
 
 ```nix
-pointy.type.derivation = { };
-# or, to make repository source files available at build time:
-pointy.type.derivation = { withSrcFiles = true; };
+pointy.type.derivation = {
+  displayName = "Alignment";
+  description = "Align reads to a library with STAR.";
+  withSrcFiles = false; # default
+};
 ```
 
 This declares a runnable derivation step.
 
-If `withSrcFiles = true`, Pointy symlinks every top-level entry from `srcFiles/<step-id>/` into the build working directory before the build runs, and the frontend shows a **Source Files** section for that step type.
+- `displayName` (optional) — friendly name shown in table headings and modal titles.
+- `description` (optional) — intro paragraph rendered in the create/edit modal.
+- `withSrcFiles = true` makes Pointy symlink every top-level entry from `srcFiles/<step-id>/` into the build working directory before the build runs, and the frontend shows a **Source Files** section for that step type.
 
 ### `pointy.type.fileUpload`
 
 ```nix
 pointy.type.fileUpload = {
   allowedExtensions = [ ".fastq.gz" ".fastq" ];
-  description = "sequencing reads";
+  displayName = "Data Source";
+  description = "Sequencing reads as FASTQ files.";
 };
 ```
 
 This declares a file upload step.
 
 - `allowedExtensions` restricts the frontend file picker.
-- `description` is carried in the generated step schema.
+- `displayName` (optional) — friendly name shown in table headings and modal titles.
+- `description` (optional) — intro paragraph rendered in the create/edit modal.
 - file-upload templates usually also declare an `uploaded` option of type `lib.types.package`; Pointy fills that option automatically.
 
 At build time, `cfg.uploaded` is a Nix store path pointing at the uploaded payload directory.
@@ -48,7 +63,8 @@ These are used inside `options.pointy.<name>` to declare the arguments that user
 ```nix
 lib.mkOption {
   type = pointy.string {
-    description = "schema metadata";
+    displayName = "Extra STAR args"; # optional, used as form label
+    description = "Help text shown under the field.";
     display = { ... }; # optional, see below
   };
   default = ""; # optional
@@ -68,7 +84,8 @@ By default this renders a plain text input. The optional `display` attribute cha
 ```nix
 lib.mkOption {
   type = pointy.step {
-    description = "schema metadata";
+    displayName = "Reads"; # optional, used as form label
+    description = "Help text shown under the field.";
     allowedTypes = [ "typeA" "typeB" ]; # optional
   };
 }
@@ -84,17 +101,23 @@ At build time the selected value resolves to the Nix store path of the chosen st
 
 ```nix
 lib.mkOption {
-  type = pointy.listOf (pointy.step { description = "dependency"; });
+  type = pointy.listOf (pointy.step {
+    displayName = "Step deps";
+    description = "Other steps to symlink into the build directory.";
+  });
   default = [];
 }
 # or a list of strings:
 lib.mkOption {
-  type = pointy.listOf (pointy.string { description = "nixpkgs attribute"; });
+  type = pointy.listOf (pointy.string {
+    displayName = "nixpkgs deps";
+    description = "Attribute paths into pkgs.";
+  });
   default = [];
 }
 ```
 
-This wraps another Pointy type to make it repeatable. The UI renders an add/remove list, and the final value becomes a Nix list of the resolved inner values.
+This wraps another Pointy type to make it repeatable. The UI renders an add/remove list, and the final value becomes a Nix list of the resolved inner values. The inner type's `displayName` and `description` apply to the whole list field.
 
 ---
 

--- a/docs/pages/type-reference.md
+++ b/docs/pages/type-reference.md
@@ -4,14 +4,29 @@ This page documents the option types that template authors use inside `options.p
 
 Pointy serializes these types into `.#pointy.stepConfig`, which the frontend uses to decide which widgets to render.
 
-## User-facing labels and hints
+## Top-level template metadata
 
-Two optional fields control what users see in the UI:
+These fields sit at the top level of a template file, alongside `sortKey`, `pointy.type`, and `module`:
 
-- `displayName` — short label shown in table headings, modal titles, form labels, and the type chip in step selectors. When omitted, the raw attribute name is used.
-- `description` — longer help text shown as a hint under the field (for option types) or as an intro paragraph in the create/edit modal (for step type declarations).
+- `displayName` (optional) — short label shown in table headings, modal titles, and the type chip in step selectors. When omitted, the raw attribute name is used.
+- `description` (optional) — intro paragraph rendered in the create/edit modal.
+- `sortKey` (optional) — integer that orders step-type sections in the project view.
 
-Both can be set on step type declarations (`pointy.type.derivation`, `pointy.type.fileUpload`) and on option types (`pointy.string`, `pointy.step`, indirectly on `pointy.listOf` via its inner type).
+Example:
+
+```nix
+{
+  sortKey = 3;
+  displayName = "Alignment";
+  description = "Align reads to a library with STAR.";
+
+  pointy.type.derivation = { };
+
+  module = { ... };
+}
+```
+
+For per-option labels and hints, see `pointy.string` / `pointy.step` below.
 
 ## Step type declarations
 
@@ -21,16 +36,12 @@ These are set at the top level of a template file, outside `module`, to tell Poi
 
 ```nix
 pointy.type.derivation = {
-  displayName = "Alignment";
-  description = "Align reads to a library with STAR.";
   withSrcFiles = false; # default
 };
 ```
 
 This declares a runnable derivation step.
 
-- `displayName` (optional) — friendly name shown in table headings and modal titles.
-- `description` (optional) — intro paragraph rendered in the create/edit modal.
 - `withSrcFiles = true` makes Pointy symlink every top-level entry from `srcFiles/<step-id>/` into the build working directory before the build runs, and the frontend shows a **Source Files** section for that step type.
 
 ### `pointy.type.fileUpload`
@@ -38,16 +49,12 @@ This declares a runnable derivation step.
 ```nix
 pointy.type.fileUpload = {
   allowedExtensions = [ ".fastq.gz" ".fastq" ];
-  displayName = "Data Source";
-  description = "Sequencing reads as FASTQ files.";
 };
 ```
 
 This declares a file upload step.
 
 - `allowedExtensions` restricts the frontend file picker.
-- `displayName` (optional) — friendly name shown in table headings and modal titles.
-- `description` (optional) — intro paragraph rendered in the create/edit modal.
 - file-upload templates usually also declare an `uploaded` option of type `lib.types.package`; Pointy fills that option automatically.
 
 At build time, `cfg.uploaded` is a Nix store path pointing at the uploaded payload directory.

--- a/docs/pages/user-repo-setup.md
+++ b/docs/pages/user-repo-setup.md
@@ -124,7 +124,8 @@ This pattern matches the sample `dataSource` template:
 {
   pointy.type.fileUpload = {
     allowedExtensions = [ ".fastq.gz" ".fastq" ".fq.gz" ".fq" ];
-    description = "data source";
+    displayName = "Data Source";
+    description = "Sequencing reads as FASTQ files.";
   };
 
   module =
@@ -173,7 +174,10 @@ This pattern matches the sample `fastqc` template:
 
 ```nix
 {
-  pointy.type.derivation = { };
+  pointy.type.derivation = {
+    displayName = "FastQC";
+    description = "Per-base quality report with FastQC.";
+  };
 
   module =
     { dream2nix, config, lib, pkgs, ... }:
@@ -213,13 +217,15 @@ This pattern matches the sample `fastqc` template:
         dataSource = lib.mkOption {
           type = pointy.step {
             allowedTypes = [ "dataSource" "merge" ];
-            description = "The data source for FastQC";
+            displayName = "Reads";
+            description = "FASTQ source to QC.";
           };
         };
 
         extraArgs = lib.mkOption {
           type = pointy.string {
-            description = "Extra arguments for the fastqc command";
+            displayName = "Extra FastQC args";
+            description = "Extra flags appended to the fastqc command.";
             display.command = "fastqc";
           };
           default = "";
@@ -233,6 +239,7 @@ Notes:
 
 - `pointy.step` options resolve to upstream step outputs at build time.
 - `pointy.string` with `display.command` renders a command-style argument field in the UI.
+- `displayName` becomes the visible form label; `description` becomes the hint shown under the field.
 - `passthru.meta.pointy` should include both the template `type` and the step `id`.
 
 For the available option types, see the [Type Reference](type-reference.md).

--- a/docs/pages/user-repo-setup.md
+++ b/docs/pages/user-repo-setup.md
@@ -122,10 +122,12 @@ This pattern matches the sample `dataSource` template:
 
 ```nix
 {
+  sortKey = 2;
+  displayName = "Data Source";
+  description = "Sequencing reads as FASTQ files.";
+
   pointy.type.fileUpload = {
     allowedExtensions = [ ".fastq.gz" ".fastq" ".fq.gz" ".fq" ];
-    displayName = "Data Source";
-    description = "Sequencing reads as FASTQ files.";
   };
 
   module =
@@ -174,10 +176,11 @@ This pattern matches the sample `fastqc` template:
 
 ```nix
 {
-  pointy.type.derivation = {
-    displayName = "FastQC";
-    description = "Per-base quality report with FastQC.";
-  };
+  sortKey = 5;
+  displayName = "FastQC";
+  description = "Per-base quality report with FastQC.";
+
+  pointy.type.derivation = { };
 
   module =
     { dream2nix, config, lib, pkgs, ... }:

--- a/frontend/src/Api/Decode.elm
+++ b/frontend/src/Api/Decode.elm
@@ -280,6 +280,7 @@ argType =
     Decode.succeed ArgType
         |> required "description" Decode.string
         |> required "type" stepArgType
+        |> optional "displayName" (maybe Decode.string) Nothing
 
 
 stepType : Decoder StepType
@@ -314,6 +315,8 @@ stepConfigEntry =
     Decode.succeed StepConfigEntry
         |> required "type" stepType
         |> optional "sortKey" (maybe Decode.int) Nothing
+        |> optional "displayName" (maybe Decode.string) Nothing
+        |> optional "description" (maybe Decode.string) Nothing
 
 
 stepConfig : Decoder StepConfig

--- a/frontend/src/Components/Select.elm
+++ b/frontend/src/Components/Select.elm
@@ -259,8 +259,16 @@ view { optic, selectState, selected_, availableItems, readOnly, hasChanged, labe
     in
     Html.div
         [ class "form-field", class "select-container", classList [ ( "select-container--right", alignRight ) ] ]
-        [ Html.viewIf (not <| String.isEmpty label) (Html.label [ class "form-label" ] [ Html.text label ])
-        , Html.viewMaybe (\h -> Html.small [ class "form-hint" ] [ Html.text h ]) mHint
+        [ Html.viewIf (not <| String.isEmpty label) <|
+            case mHint of
+                Nothing ->
+                    Html.label [ class "form-label" ] [ Html.text label ]
+
+                Just hint ->
+                    Html.div [ class "form-label-group" ]
+                        [ Html.label [ class "form-label" ] [ Html.text label ]
+                        , Html.small [ class "form-hint" ] [ Html.text hint ]
+                        ]
         , Html.Keyed.node "div"
             [ class "tag-wrapper", class "form-input", classList [ ( "disabled", readOnly ), ( "field-changed", hasChanged ) ] ]
             ((inputIcon |> Maybe.unwrap [] (\icon -> [ ( "form-input-icon", iconCustom True icon [ class "form-input-icon" ] ) ]))

--- a/frontend/src/Components/Select.elm
+++ b/frontend/src/Components/Select.elm
@@ -104,6 +104,7 @@ view :
     , readOnly : Bool
     , hasChanged : Bool
     , label : String
+    , mHint : Maybe String
     , placeholder : String
     , inputIcon : Maybe String
     , toInputItemName : Item -> String
@@ -120,7 +121,7 @@ view :
     , inputItemStyle : Item -> List (Html.Attribute Never)
     }
     -> Html (Flow s ())
-view { optic, selectState, selected_, availableItems, readOnly, hasChanged, label, placeholder, inputIcon, toInputItemName, toInputItemTooltip, onInputItemClick, toMenuItemName, toMenuItemTooltip, onChange, onRemove, activeAfterSelect, clearInputAfterSelect, onSelect, alignRight, inputItemStyle } =
+view { optic, selectState, selected_, availableItems, readOnly, hasChanged, label, mHint, placeholder, inputIcon, toInputItemName, toInputItemTooltip, onInputItemClick, toMenuItemName, toMenuItemTooltip, onChange, onRemove, activeAfterSelect, clearInputAfterSelect, onSelect, alignRight, inputItemStyle } =
     let
         optic_ =
             remkT optic
@@ -259,6 +260,7 @@ view { optic, selectState, selected_, availableItems, readOnly, hasChanged, labe
     Html.div
         [ class "form-field", class "select-container", classList [ ( "select-container--right", alignRight ) ] ]
         [ Html.viewIf (not <| String.isEmpty label) (Html.label [ class "form-label" ] [ Html.text label ])
+        , Html.viewMaybe (\h -> Html.small [ class "form-hint" ] [ Html.text h ]) mHint
         , Html.Keyed.node "div"
             [ class "tag-wrapper", class "form-input", classList [ ( "disabled", readOnly ), ( "field-changed", hasChanged ) ] ]
             ((inputIcon |> Maybe.unwrap [] (\icon -> [ ( "form-input-icon", iconCustom True icon [ class "form-input-icon" ] ) ]))

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -96,7 +96,7 @@ dndSubscription model =
         |> Maybe.unwrap []
             (\config ->
                 Actions.dndSub model Nothing (Specs.projects config)
-                    :: List.map (\( name, entry ) -> Actions.dndSub model mProjectId (Specs.steps name entry.stepType)) (Dict.toList config)
+                    :: List.map (\( name, entry ) -> Actions.dndSub model mProjectId (Specs.steps name entry)) (Dict.toList config)
             )
         |> Sub.batch
 

--- a/frontend/src/Model/Shadow.elm
+++ b/frontend/src/Model/Shadow.elm
@@ -68,7 +68,7 @@ tListValue =
 
 
 type alias ArgType =
-    { description : String, type_ : StepArgType }
+    { description : String, type_ : StepArgType, displayName : Maybe String }
 
 
 type StepType
@@ -98,6 +98,8 @@ derivation =
 type alias StepConfigEntry =
     { stepType : StepType
     , sortKey : Maybe Int
+    , displayName : Maybe String
+    , description : Maybe String
     }
 
 

--- a/frontend/src/Model/TableSpec.elm
+++ b/frontend/src/Model/TableSpec.elm
@@ -3,6 +3,7 @@ module Model.TableSpec exposing
     , TableSpec(..)
     , getApiPath
     , getDefaultRecord
+    , getDescription
     , getDirectoryView
     , getDisplayName
     , getEncodeRecord
@@ -37,6 +38,7 @@ type TableSpec a
         , defaultRecord : a
         , apiPath : String
         , displayName : String
+        , description : Maybe String
         , upsertRecord : TableSpec a -> Flow Model ()
         }
 
@@ -58,6 +60,11 @@ getName (TableSpec spec) =
 getDisplayName : TableSpec a -> String
 getDisplayName (TableSpec spec) =
     spec.displayName
+
+
+getDescription : TableSpec a -> Maybe String
+getDescription (TableSpec spec) =
+    spec.description
 
 
 getLens : TableSpec a -> Traversal Model (Table a) x y

--- a/frontend/src/Specs.elm
+++ b/frontend/src/Specs.elm
@@ -9,12 +9,16 @@ import Dict
 import Extra.Accessors exposing (where_)
 import Model.Core exposing (ProjectRecord, StepRecord, TableTag(..), initialTable)
 import Model.Lenses as Lenses exposing (currentTableOf)
-import Model.Shadow as Shadow exposing (StepConfig, StepType, WithSrcFiles(..))
+import Model.Shadow as Shadow exposing (StepConfig, StepConfigEntry, WithSrcFiles(..))
 import Model.TableSpec exposing (TableSpec(..))
 
 
-steps : String -> StepType -> TableSpec StepRecord
-steps name stepType =
+steps : String -> StepConfigEntry -> TableSpec StepRecord
+steps name entry =
+    let
+        stepType =
+            entry.stepType
+    in
     TableSpec
         { tag = TagSteps name stepType
         , name = name
@@ -45,7 +49,8 @@ steps name stepType =
                 , expanded = False
                 }
             }
-        , displayName = name
+        , displayName = Maybe.withDefault name entry.displayName
+        , description = entry.description
         , apiPath = "/step"
         , upsertRecord = Actions.upsertStep
         }
@@ -72,6 +77,7 @@ projects stepConfig =
             , isUpdating = False
             }
         , displayName = "Projects"
+        , description = Nothing
         , apiPath = "/projects"
         , upsertRecord = Actions.upsertProject
         }

--- a/frontend/src/View/Lib.elm
+++ b/frontend/src/View/Lib.elm
@@ -39,6 +39,7 @@ viewSearchBox model =
         , readOnly = False
         , hasChanged = False
         , label = ""
+        , mHint = Nothing
         , placeholder = "Search for steps"
         , inputIcon = Just "search"
         , toInputItemName = .name

--- a/frontend/src/View/Shadow.elm
+++ b/frontend/src/View/Shadow.elm
@@ -10,7 +10,7 @@ import Html.Attributes
 import Html.Extra as Html
 import Model.Core as Model exposing (Model, ProjectRecord, StepRecord, Table)
 import Model.Lenses exposing (mCommit, route)
-import Model.Shadow exposing (StepType(..))
+import Model.Shadow exposing (StepConfigEntry, StepType(..))
 import Model.TableSpec as TableSpec
 import Route
 import Specs
@@ -68,16 +68,19 @@ viewProject model proj =
                                 |> Maybe.map (\entry -> ( sectionName, entry, steps ))
                         )
                     |> List.sortBy (\( name, entry, _ ) -> ( entry.sortKey |> Maybe.withDefault 2147483647, name ))
-                    |> List.map (\( sectionName, entry, steps ) -> viewSection model sectionName entry.stepType steps)
+                    |> List.map (\( sectionName, entry, steps ) -> viewSection model sectionName entry steps)
                 )
         }
 
 
-viewSection : Model -> String -> StepType -> Table StepRecord -> Html (Flow Model ())
-viewSection model sectionName stepType steps =
+viewSection : Model -> String -> StepConfigEntry -> Table StepRecord -> Html (Flow Model ())
+viewSection model sectionName entry steps =
     let
+        stepType =
+            entry.stepType
+
         spec =
-            Specs.steps sectionName stepType
+            Specs.steps sectionName entry
 
         isReadOnly =
             has (route << Route.project << mCommit << just) model

--- a/frontend/src/View/Table.elm
+++ b/frontend/src/View/Table.elm
@@ -427,7 +427,7 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                              else
                                 "chevron_right"
                             )
-                        , Html.span [ class "table-content-header" ] [ Html.text (TableSpec.getName spec) ]
+                        , Html.span [ class "table-content-header" ] [ Html.text (TableSpec.getDisplayName spec) ]
                         , ApiData.unwrap Html.nothing (viewStatusCountBadge spec) table.records
                         ]
                     , Html.div [ class "table-header-controls" ]
@@ -511,8 +511,9 @@ viewAddOrEditRecordForm model spec table record =
                     try (records << success << by .id record.id) table
             in
             textField
-                { label = "Name:"
-                , placeholder = TableSpec.getName spec ++ " name"
+                { label = "Name"
+                , mHint = Nothing
+                , placeholder = TableSpec.getDisplayName spec ++ " name"
                 , value = record.name
                 , onInput = Actions.editRecordName (TableSpec.getLens spec)
                 , hasChanged = fieldChanged .name record.name originalRecord
@@ -571,6 +572,7 @@ viewAddOrEditRecordForm model spec table record =
                 , readOnly = False
                 , hasChanged = False
                 , label = "Select records"
+                , mHint = Nothing
                 , placeholder = ""
                 , inputIcon = Nothing
                 , toInputItemName = .name
@@ -626,6 +628,14 @@ viewAddOrEditRecordForm model spec table record =
     Html.div [ class "table-form-wrapper" ]
         [ Html.div [ formClasses, Events.on "keydown" handleEnter ]
             [ Html.header [ class "form-header" ] [ Html.text headerTitle ]
+            , Html.viewMaybe
+                (\d -> Html.p [ class "form-intro" ] [ Html.text d ])
+                (if editing || table.addMode == AddNew then
+                    TableSpec.getDescription spec
+
+                 else
+                    Nothing
+                )
             , Html.div [ class "form-body" ]
                 [ Html.viewIf (not editing && TableSpec.getTag spec /= TagProjects) modeSelector
                 , Html.viewIf (not editing && table.addMode == AddExisting && TableSpec.getTag spec /= TagProjects) <| Html.Lazy.lazy viewSelectExisting table.selectExistingSteps
@@ -680,8 +690,26 @@ viewStepExtraFormFields model readOnly tableId stepDef =
                 |> Maybe.andThen .id
                 |> Maybe.andThen (\id_ -> try (currentTableOf tableId << records << success << by .id (Just id_)) model)
 
-        viewField ( paramName, { type_ } ) =
+        stepConfig_ =
+            Model.getStepConfig model |> ApiData.toMaybe |> Maybe.withDefault Dict.empty
+
+        typeDisplayName typeName =
+            Dict.get typeName stepConfig_
+                |> Maybe.andThen .displayName
+                |> Maybe.withDefault typeName
+
+        viewField ( paramName, { type_, description, displayName } ) =
             let
+                fieldLabel =
+                    Maybe.withDefault paramName displayName
+
+                fieldHint =
+                    if String.isEmpty description then
+                        Nothing
+
+                    else
+                        Just description
+
                 paramLens =
                     argsLens << key paramName
 
@@ -700,7 +728,8 @@ viewStepExtraFormFields model readOnly tableId stepDef =
 
                 buildListField listLens tagStrings addTag =
                     listField
-                        { label = paramName ++ ":"
+                        { label = fieldLabel
+                        , mHint = fieldHint
                         , tags = tagStrings
                         , onAdd = addTag
                         , onRemoveLast = Flow.modify (over listLens (\xs -> List.take (List.length xs - 1) xs)) |> Flow.seq (focus fieldId)
@@ -745,7 +774,16 @@ viewStepExtraFormFields model readOnly tableId stepDef =
                                 |> List.filter (\item -> not (List.member item.id selectedIds))
 
                         toTooltip =
-                            .id >> Maybe.unwrap [] (\id -> [ "id: " ++ String.fromInt id ])
+                            .id
+                                >> Maybe.unwrap []
+                                    (\id ->
+                                        case getStep (Just id) of
+                                            Just step ->
+                                                [ "id: " ++ String.fromInt id ++ " — " ++ typeDisplayName step.type_ ]
+
+                                            Nothing ->
+                                                [ "id: " ++ String.fromInt id ]
+                                    )
 
                         toHighlightRoute stepId =
                             try currentProjectId model
@@ -769,7 +807,8 @@ viewStepExtraFormFields model readOnly tableId stepDef =
                         , availableItems = availableItems
                         , readOnly = readOnly
                         , hasChanged = fieldHasChanged
-                        , label = paramName ++ ":"
+                        , label = fieldLabel
+                        , mHint = fieldHint
                         , placeholder = ""
                         , inputIcon = Nothing
                         , toInputItemName = .name
@@ -777,7 +816,7 @@ viewStepExtraFormFields model readOnly tableId stepDef =
                         , onInputItemClick = .id >> Maybe.andThen toHighlightRoute >> Maybe.map Actions.goToRoute
                         , toMenuItemName =
                             \item ->
-                                Maybe.map2 (\id s -> "[" ++ String.fromInt id ++ "] [" ++ s.type_ ++ "] " ++ item.name) item.id (getStep item.id) |> Maybe.withDefault item.name
+                                Maybe.map2 (\id s -> "[" ++ String.fromInt id ++ "] [" ++ typeDisplayName s.type_ ++ "] " ++ item.name) item.id (getStep item.id) |> Maybe.withDefault item.name
                         , toMenuItemTooltip = toTooltip
                         , onChange = Flow.pure ()
                         , onRemove = .id >> Maybe.unwrap (Flow.pure ()) onRemoveStep
@@ -808,8 +847,9 @@ viewStepExtraFormFields model readOnly tableId stepDef =
                     case display of
                         TextField ->
                             textField
-                                { label = paramName ++ ":"
-                                , placeholder = paramName
+                                { label = fieldLabel
+                                , mHint = fieldHint
+                                , placeholder = fieldLabel
                                 , value = Maybe.withDefault "" <| try (paramLens << just << tStringValue) model
                                 , onInput = Flow.modify << set paramLens << Just << TStringValue
                                 , hasChanged = fieldChanged (try (args << key paramName)) (try paramLens model) originalRecord
@@ -819,7 +859,8 @@ viewStepExtraFormFields model readOnly tableId stepDef =
 
                         TextArea ->
                             textArea
-                                { label = paramName ++ ":"
+                                { label = fieldLabel
+                                , mHint = fieldHint
                                 , placeholder = ""
                                 , value = Maybe.withDefault "" <| try (paramLens << just << tStringValue) model
                                 , onInput = Flow.modify << set paramLens << Just << TStringValue
@@ -830,8 +871,9 @@ viewStepExtraFormFields model readOnly tableId stepDef =
 
                         Command cmdPrefix ->
                             commandField
-                                { label = paramName ++ ":"
-                                , placeholder = paramName
+                                { label = fieldLabel
+                                , mHint = fieldHint
+                                , placeholder = fieldLabel
                                 , value = Maybe.withDefault "" <| try (paramLens << just << tStringValue) model
                                 , onInput = Flow.modify << set paramLens << Just << TStringValue
                                 , hasChanged = fieldChanged (try (args << key paramName)) (try paramLens model) originalRecord
@@ -924,8 +966,14 @@ viewStepNoteField model readOnly tableId =
         ]
 
 
+viewFormHint : Maybe String -> Html msg
+viewFormHint mHint =
+    Html.viewMaybe (\h -> Html.small [ class "form-hint" ] [ Html.text h ]) mHint
+
+
 textField :
     { label : String
+    , mHint : Maybe String
     , placeholder : String
     , value : String
     , onInput : String -> Flow Model ()
@@ -936,7 +984,8 @@ textField :
     -> Html (Flow Model ())
 textField config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label" ] [ Html.text config.label ]
+        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
+        , viewFormHint config.mHint
         , Html.input
             [ type_ "text"
             , value config.value
@@ -953,6 +1002,7 @@ textField config =
 
 commandField :
     { label : String
+    , mHint : Maybe String
     , placeholder : String
     , value : String
     , onInput : String -> Flow Model ()
@@ -964,7 +1014,8 @@ commandField :
     -> Html (Flow Model ())
 commandField config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label" ] [ Html.text config.label ]
+        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
+        , viewFormHint config.mHint
         , Html.div
             [ class "command-input"
             , classList [ ( "field-changed", config.hasChanged ), ( "disabled", config.readOnly ) ]
@@ -988,6 +1039,7 @@ commandField config =
 
 textArea :
     { label : String
+    , mHint : Maybe String
     , placeholder : String
     , value : String
     , onInput : String -> Flow Model ()
@@ -998,7 +1050,8 @@ textArea :
     -> Html (Flow Model ())
 textArea config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label" ] [ Html.text config.label ]
+        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
+        , viewFormHint config.mHint
         , Html.textarea
             [ value config.value
             , Events.onInput config.onInput
@@ -1017,6 +1070,7 @@ textArea config =
 
 listField :
     { label : String
+    , mHint : Maybe String
     , tags :
         List
             { body : Html (Flow Model ())
@@ -1033,7 +1087,8 @@ listField :
     -> Html (Flow Model ())
 listField config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label" ] [ Html.text config.label ]
+        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
+        , viewFormHint config.mHint
         , Html.Keyed.node "div"
             [ class "tag-wrapper"
             , class "form-input"

--- a/frontend/src/View/Table.elm
+++ b/frontend/src/View/Table.elm
@@ -951,7 +951,7 @@ viewStepNoteField model readOnly tableId =
                 |> Maybe.andThen (\id_ -> try (currentTableOf tableId << records << success << by .id (Just id_)) model)
     in
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label" ] [ Html.text "Note:" ]
+        [ Html.label [ class "form-label", for (tableId ++ "-note-input") ] [ Html.text "Note" ]
         , Html.textarea
             [ value currentNote
             , Events.onInput (Flow.modify << set noteLens)
@@ -966,9 +966,17 @@ viewStepNoteField model readOnly tableId =
         ]
 
 
-viewFormHint : Maybe String -> Html msg
-viewFormHint mHint =
-    Html.viewMaybe (\h -> Html.small [ class "form-hint" ] [ Html.text h ]) mHint
+viewLabelWithHint : { label : String, mHint : Maybe String, htmlFor : String } -> Html msg
+viewLabelWithHint { label, mHint, htmlFor } =
+    case mHint of
+        Nothing ->
+            Html.label [ class "form-label", for htmlFor ] [ Html.text label ]
+
+        Just hint ->
+            Html.div [ class "form-label-group" ]
+                [ Html.label [ class "form-label", for htmlFor ] [ Html.text label ]
+                , Html.small [ class "form-hint" ] [ Html.text hint ]
+                ]
 
 
 textField :
@@ -984,8 +992,7 @@ textField :
     -> Html (Flow Model ())
 textField config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
-        , viewFormHint config.mHint
+        [ viewLabelWithHint { label = config.label, mHint = config.mHint, htmlFor = config.id }
         , Html.input
             [ type_ "text"
             , value config.value
@@ -1014,8 +1021,7 @@ commandField :
     -> Html (Flow Model ())
 commandField config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
-        , viewFormHint config.mHint
+        [ viewLabelWithHint { label = config.label, mHint = config.mHint, htmlFor = config.id }
         , Html.div
             [ class "command-input"
             , classList [ ( "field-changed", config.hasChanged ), ( "disabled", config.readOnly ) ]
@@ -1050,8 +1056,7 @@ textArea :
     -> Html (Flow Model ())
 textArea config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
-        , viewFormHint config.mHint
+        [ viewLabelWithHint { label = config.label, mHint = config.mHint, htmlFor = config.id }
         , Html.textarea
             [ value config.value
             , Events.onInput config.onInput
@@ -1087,8 +1092,7 @@ listField :
     -> Html (Flow Model ())
 listField config =
     Html.div [ class "form-field" ]
-        [ Html.label [ class "form-label", for config.id ] [ Html.text config.label ]
-        , viewFormHint config.mHint
+        [ viewLabelWithHint { label = config.label, mHint = config.mHint, htmlFor = config.id }
         , Html.Keyed.node "div"
             [ class "tag-wrapper"
             , class "form-input"

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -650,22 +650,25 @@ $form-vertical-gap: var(--spacing-md);
   gap: 0.25rem;
 }
 
+.form-label-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .form-hint {
   display: block;
   color: var(--text-muted);
   font-size: var(--font-size-sm);
   font-weight: 400;
   line-height: 1.3;
-  margin-top: calc(var(--spacing-xs) * -0.5);
 }
 
 .form-intro {
+  padding: var(--spacing-sm) var(--spacing-md);
   color: var(--text-secondary);
   font-size: var(--font-size-sm);
   line-height: 1.4;
-  margin: 0 var(--spacing-xl) var(--spacing-sm);
-  padding: 0 0 var(--spacing-sm);
-  border-bottom: 1px solid var(--line-color);
 }
 
 .form-input {

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -650,6 +650,24 @@ $form-vertical-gap: var(--spacing-md);
   gap: 0.25rem;
 }
 
+.form-hint {
+  display: block;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  line-height: 1.3;
+  margin-top: calc(var(--spacing-xs) * -0.5);
+}
+
+.form-intro {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  margin: 0 var(--spacing-xl) var(--spacing-sm);
+  padding: 0 0 var(--spacing-sm);
+  border-bottom: 1px solid var(--line-color);
+}
+
 .form-input {
   @include mixins.form-control;
 }


### PR DESCRIPTION
Use the new optional `displayName` and `description` fields from `pointy.stepConfig` when rendering steps:

- Table headings + add/edit modal titles use the template `displayName` (fallback: raw template name).
- Per-field form labels use the option `displayName` (fallback: option key).
- Per-field `description` is rendered as a small hint under the label.
- Template-level `description` is rendered as an intro paragraph in the create/edit modal.
- Step selector menu and tooltip show the friendly type name in the `[type]` chip (color still keys off the raw type for stability).

Decoders treat all new fields as optional, so user repos that have not adopted them still render exactly as before.

Docs (`type-reference.md`, `user-repo-setup.md`) updated to document the new fields and drop the "not currently rendered" disclaimer.

Depends on: https://github.com/421anon/pointy-stdlib/pull/new/feat/template-display-names