### PR TITLE
treat no-op save as success, not 400

### DIFF
--- a/backend/src/UserRepo.hs
+++ b/backend/src/UserRepo.hs
@@ -308,7 +308,7 @@ commitAndPushChanges (WriteRepoContext worktreePath) message = ExceptT $ do
             (statusCode, statusOut, statusErr) <- runGitIn worktreePath ["status", "--porcelain"]
             case statusCode of
                 ExitFailure code -> return $ Left $ formatGitFailure "git status" code statusOut statusErr
-                ExitSuccess | null statusOut -> return $ Left "No changes to commit; nothing was pushed."
+                ExitSuccess | null statusOut -> return $ Right ()
                 ExitSuccess -> do
                     (commitCode, commitOut, commitErr) <- runGitIn worktreePath ["commit", "-m", message]
                     case commitCode of


### PR DESCRIPTION
Fixes #14

`commitAndPushChanges` returned `Left "No changes to commit; nothing was pushed."` when the worktree was clean, which every PATCH/assign/upload caller mapped to a 400/500. Re-saving an unchanged step therefore surfaced as `"Invalid request."` in the UI.

PATCH must be idempotent: rewriting identical canonical Nix is a successful no-op, not a failure.

This restores the original `Right ()` for the empty-status branch, while genuine `git add`, `status`, `commit`, and `push` failures still propagate.