### PR TITLE
fix unsaved changes lost on edit window change

### DIFF
--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -51,6 +51,14 @@ toggleAddOrEditRecordForm inspected spec mRecordId =
     let
         updateTable t =
             let
+                stashed =
+                    case ( t.inspected, t.edited ) of
+                        ( False, Just r ) ->
+                            set (draftAt r.id) (Just r) t
+
+                        _ ->
+                            t
+
                 mRecordToEdit =
                     try (success << by .id mRecordId) t.records
 
@@ -61,7 +69,7 @@ toggleAddOrEditRecordForm inspected spec mRecordId =
                     (t.edited |> Maybe.andThen .id) == Nothing
 
                 togglingCurrentRecord =
-                    mRecordToEdit == t.edited
+                    (t.edited |> Maybe.map .id) == Just mRecordId
 
                 clickedNewRecord =
                     mRecordToEdit == Nothing
@@ -73,10 +81,16 @@ toggleAddOrEditRecordForm inspected spec mRecordId =
                     if formIsOpen && not switchingMode && (togglingCurrentRecord || (clickedNewRecord && notEditingExistingRecord)) then
                         Nothing
 
-                    else
+                    else if inspected then
                         Just (Maybe.withDefault (TableSpec.getDefaultRecord spec) mRecordToEdit)
+
+                    else
+                        get (draftAt mRecordId) stashed
+                            |> Maybe.orElse mRecordToEdit
+                            |> Maybe.withDefault (TableSpec.getDefaultRecord spec)
+                            |> Just
             in
-            { t | nameEditOnly = False, inspected = inspected, edited = newedited }
+            { stashed | nameEditOnly = False, inspected = inspected, edited = newedited }
 
         scrollAction =
             Flow.attemptTask (Scroll.scrollY (Maybe.unwrap ("table-" ++ TableSpec.getName spec) String.fromInt mRecordId) 0 0)
@@ -421,7 +435,19 @@ upsertStep spec =
 
 endRecordEdit : A_Traversal s (Table (BaseRecord a)) -> Flow s ()
 endRecordEdit lens =
-    Flow.over (remkT lens) (\t -> { t | edited = Nothing, addMode = AddNew })
+    Flow.over (remkT lens)
+        (\t ->
+            let
+                cleared =
+                    case ( t.inspected, t.edited ) of
+                        ( False, Just r ) ->
+                            set (draftAt r.id) Nothing t
+
+                        _ ->
+                            t
+            in
+            { cleared | edited = Nothing, addMode = AddNew }
+        )
 
 
 onUrlRequest : Browser.UrlRequest -> Flow Model ()

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -64,6 +64,8 @@ type alias Table a =
     , isOpen : Bool
     , showHiddenRecords : Bool
     , edited : Maybe a
+    , drafts : Dict Int a
+    , newDraft : Maybe a
     , addMode : AddMode
     , nameEditOnly : Bool
     , inspected : Bool
@@ -210,6 +212,8 @@ initialTable =
     , isOpen = True
     , showHiddenRecords = False
     , edited = Nothing
+    , drafts = Dict.empty
+    , newDraft = Nothing
     , addMode = AddNew
     , nameEditOnly = False
     , inspected = False

--- a/frontend/src/Model/Lenses.elm
+++ b/frontend/src/Model/Lenses.elm
@@ -114,6 +114,26 @@ edited =
     lens ".edited" .edited (\t record -> { t | edited = record })
 
 
+drafts : Lens ls { a | drafts : b } b x y
+drafts =
+    lens ".drafts" .drafts (\t drafts_ -> { t | drafts = drafts_ })
+
+
+newDraft : Lens ls { a | newDraft : Maybe b } (Maybe b) x y
+newDraft =
+    lens ".newDraft" .newDraft (\t record -> { t | newDraft = record })
+
+
+draftAt : Maybe Int -> Lens ls (Table a) (Maybe a) x y
+draftAt mId =
+    case mId of
+        Just rid ->
+            drafts << Dict.Accessors.at_ String.fromInt rid
+
+        Nothing ->
+            newDraft
+
+
 stepConfig : Lens ls Model (ApiData StepConfig) x y
 stepConfig =
     lens ".stepConfig" Model.getStepConfig (\(Model m) stepConfig_ -> Model { m | stepConfig = stepConfig_ })


### PR DESCRIPTION
Fixes #13

Switching the open record form between inspect/edit mode, or opening the Add form, used to overwrite `t.edited` with the saved record, dropping the user's typed changes.

This change stashes `t.edited` into per-record draft slots when leaving edit mode and restores it when returning. Inspect mode still shows the saved record.

`endRecordEdit` clears the draft for the current edited key after Cancel or Save, so explicit discard/save still wins.