### PR TITLE
fix squashed empty nixDeps input in inspect form

### DIFF
--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -1289,7 +1289,8 @@ select.field-changed,
   height: 24px;
 }
 
-.tag-wrapper:has(.list-field-input) {
+.tag-wrapper:has(.list-field-input),
+.tag-wrapper.disabled {
   min-height: 34px;
 }
 


### PR DESCRIPTION
Fixes #23

Inspect mode replaces `.list-field-input` with `Html.nothing`, so the `:has(.list-field-input)` min-height rule no longer matched and the empty wrapper collapsed to ~8px.

This extends the rule to `.tag-wrapper.disabled` so readonly empty list fields keep the 34px input height.