### PR TITLE
graceful empty source files

### DIFF
--- a/backend/src/Handlers/SrcFiles.hs
+++ b/backend/src/Handlers/SrcFiles.hs
@@ -17,6 +17,7 @@ import GHC.Generics (Generic)
 import Handlers.Store (DirEntry, downloadHandler, listHandler)
 import Servant (Handler, Header, Headers, ServerError (..), err500, throwError)
 import qualified Servant.Types.SourceT as S
+import System.Directory (doesDirectoryExist)
 import System.FilePath ((</>))
 import UserRepo (runNixInRepo, withReadRepoTransaction)
 
@@ -45,7 +46,10 @@ listSrcFilesHandler :: Int -> Maybe FilePath -> Handler [DirEntry]
 listSrcFilesHandler stepId mRel = do
     basePath <- getSrcFilesBasePath
     let fullBasePath = T.unpack basePath </> show stepId
-    listHandler (T.pack fullBasePath) mRel
+    exists <- liftIO $ doesDirectoryExist fullBasePath
+    if exists
+        then listHandler (T.pack fullBasePath) mRel
+        else return []
 
 downloadSrcFilesHandler :: Int -> FilePath -> Handler (Headers '[Header "Content-Disposition" Text, Header "Content-Length" Integer] (S.SourceT IO BS.ByteString))
 downloadSrcFilesHandler stepId rel = do

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -769,19 +769,7 @@ toggleSrcEntry recordId mOpen path =
                 (\_ ->
                     callApi (allStepTables << srcFilesChildrenAt recordId path)
                         (Api.fetchSrcDirectoryContents ApiDecode.directoryItemGeneric recordId path)
-                        |> Flow.andThen
-                            (\result ->
-                                case ( List.isEmpty path, result ) of
-                                    ( True, Ok dict ) ->
-                                        if Dict.isEmpty dict then
-                                            addToast False "No source files for this step"
-
-                                        else
-                                            Flow.setAll isExpanded True
-
-                                    _ ->
-                                        Flow.pure ()
-                            )
+                        |> Flow.return ()
                 )
 
         fileAction =
@@ -804,16 +792,9 @@ toggleSrcEntry recordId mOpen path =
             let
                 newlyExpanded =
                     Maybe.withDefault (not wasExpanded) mOpen
-
-                immediateExpand =
-                    if List.isEmpty path && newlyExpanded then
-                        False
-
-                    else
-                        newlyExpanded
             in
             Flow.setAll (allStepTables << srcFilesChildrenAt recordId path) NotAsked
-                |> Flow.seq (Flow.setAll isExpanded immediateExpand)
+                |> Flow.seq (Flow.setAll isExpanded newlyExpanded)
                 |> Flow.seq (Flow.when newlyExpanded <| Flow.batchM [ folderAction, fileAction ])
                 |> Flow.return newlyExpanded
         )

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -769,7 +769,19 @@ toggleSrcEntry recordId mOpen path =
                 (\_ ->
                     callApi (allStepTables << srcFilesChildrenAt recordId path)
                         (Api.fetchSrcDirectoryContents ApiDecode.directoryItemGeneric recordId path)
-                        |> Flow.return ()
+                        |> Flow.andThen
+                            (\result ->
+                                case ( List.isEmpty path, result ) of
+                                    ( True, Ok dict ) ->
+                                        if Dict.isEmpty dict then
+                                            addToast False "No source files for this step"
+
+                                        else
+                                            Flow.setAll isExpanded True
+
+                                    _ ->
+                                        Flow.pure ()
+                            )
                 )
 
         fileAction =
@@ -792,9 +804,16 @@ toggleSrcEntry recordId mOpen path =
             let
                 newlyExpanded =
                     Maybe.withDefault (not wasExpanded) mOpen
+
+                immediateExpand =
+                    if List.isEmpty path && newlyExpanded then
+                        False
+
+                    else
+                        newlyExpanded
             in
             Flow.setAll (allStepTables << srcFilesChildrenAt recordId path) NotAsked
-                |> Flow.seq (Flow.setAll isExpanded newlyExpanded)
+                |> Flow.seq (Flow.setAll isExpanded immediateExpand)
                 |> Flow.seq (Flow.when newlyExpanded <| Flow.batchM [ folderAction, fileAction ])
                 |> Flow.return newlyExpanded
         )


### PR DESCRIPTION
Fixes #28 
                                                                                                                                                                                                                                           Clicking "Browse source files" on a step whose srcFiles/<id>/ directory didn't exist in the user repo crashed listSrcFilesHandler with a 500, surfacing as "Failed to load" in the UI.

listSrcFilesHandler now checks doesDirectoryExist fullBasePath and returns [] for missing dirs. Existing-dir path is unchanged.                                                                                                           

Empty / missing source files now matches the output file browser:

- Section opens.                                                                                                                                                                                                                             
- Existing instruction note ("Create the directory srcFiles/<id> in the user repository ...") guides the user.                                                                                                                            
- renderDirectoryContents shows "Directory is empty" inline.                                                                                                                                                                              
                                                                                                                                                                                   
No frontend changes — the existing empty-state rendering in viewSrcFilesSection and renderDirectoryContents already handle the empty case correctly once the backend returns [].