### PR TITLE
invalidate outpaths on commit switch

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (main)
 
-import Accessors exposing (just, set, try)
+import Accessors exposing (each, just, set, try)
 import Actions
 import Api.ApiData exposing (success)
 import Browser.Navigation as Nav
@@ -59,7 +59,8 @@ setRouteFromUrl url =
                 in
                 Flow.modify (set route newRoute)
                     |> Flow.seq
-                        (Flow.over (Model.Lenses.projects << Model.Lenses.records) Api.ApiData.toLoading
+                        (Flow.over (Model.Lenses.projects << Model.Lenses.records << success << each << Model.Lenses.projectStepRecords << Model.Lenses.runState) Api.ApiData.toLoading
+                            |> Flow.seq (Flow.over (Model.Lenses.projects << Model.Lenses.records) Api.ApiData.toLoading)
                             |> Flow.seq Actions.loadStepConfig
                             |> Flow.seq Actions.loadProjects
                             |> Flow.when (mOldCommit /= mNewCommit)


### PR DESCRIPTION
Fixes #18 

each step's runState carries an outPath tied to a specific commit. on commit change, records flipped to Loading but the merge in updateStepRecordTable kept the old runState — so steps still pointed at the previous commit's outPath until the SSE arrived. file fetches, downloads, iframe/img URLs all hit the old /nix/store path during that window.

fix: in setRouteFromUrl's commit-changed branch, set every step's runState to Loading before flipping records. order matters: once records is Loading the success prism stops matching, so runState must be invalidated first. callsites gating on runState << success then wait until the new SSE arrives.