### PR TITLE
scope status broadcasts to commit

### DIFF
--- a/backend/src/Bus.hs
+++ b/backend/src/Bus.hs
@@ -7,6 +7,7 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data ProjectSnapshot = ProjectSnapshot
     { projectId :: Int
+    , commit :: Text
     , statuses :: Map Int (Text, Maybe Text)
     , outPaths :: Map Int Text
     }
@@ -16,8 +17,8 @@ data ProjectSnapshot = ProjectSnapshot
 statusBus :: TChan ProjectSnapshot
 statusBus = unsafePerformIO newBroadcastTChanIO
 
-broadcastSnapshot :: Int -> Map Int (Text, Maybe Text) -> Map Int Text -> IO ()
-broadcastSnapshot pid stats paths = atomically $ writeTChan statusBus (ProjectSnapshot pid stats paths)
+broadcastSnapshot :: Int -> Text -> Map Int (Text, Maybe Text) -> Map Int Text -> IO ()
+broadcastSnapshot pid c stats paths = atomically $ writeTChan statusBus (ProjectSnapshot pid c stats paths)
 
 subscribe :: IO (TChan ProjectSnapshot)
 subscribe = atomically $ dupTChan statusBus

--- a/backend/src/Handlers/ProjectEntities.hs
+++ b/backend/src/Handlers/ProjectEntities.hs
@@ -2,12 +2,11 @@
 
 module Handlers.ProjectEntities (assignRecordHandler, assignRecordToProject, batchAssignRecordsHandler, unassignRecordHandler) where
 
-import Control.Concurrent (forkIO)
 import Control.Monad.Except (ExceptT (..), runExceptT)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import Handlers.Statuses (broadcastProjectStatus)
+import Handlers.Statuses (forkBroadcastProjectStatusAtHead)
 import OutPaths (withWriteRepoTransaction)
 import Servant (Handler, NoContent (..), err500, errBody, throwError)
 import System.FilePath ((</>))
@@ -25,7 +24,7 @@ assignRecordHandler projectId recordId = do
     case result of
         Left err -> throwError err500{errBody = TLE.encodeUtf8 (TL.pack err)}
         Right _ -> do
-            _ <- liftIO $ forkIO $ broadcastProjectStatus projectId Nothing
+            liftIO $ forkBroadcastProjectStatusAtHead projectId
             return NoContent
 
 assignRecordToProject :: WriteRepoContext -> Int -> Int -> ExceptT String IO ()
@@ -40,7 +39,7 @@ batchAssignRecordsHandler projectId recordIds = do
     case result of
         Left err -> throwError err500{errBody = TLE.encodeUtf8 (TL.pack err)}
         Right _ -> do
-            _ <- liftIO $ forkIO $ broadcastProjectStatus projectId Nothing
+            liftIO $ forkBroadcastProjectStatusAtHead projectId
             return NoContent
 
 unassignRecordHandler :: Int -> Int -> Handler NoContent
@@ -51,7 +50,7 @@ unassignRecordHandler projectId recordId = do
     case result of
         Left err -> throwError err500{errBody = TLE.encodeUtf8 (TL.pack err)}
         Right _ -> do
-            _ <- liftIO $ forkIO $ broadcastProjectStatus projectId Nothing
+            liftIO $ forkBroadcastProjectStatusAtHead projectId
             return NoContent
 
 addRecord :: Int -> T.Text

--- a/backend/src/Handlers/RunStep.hs
+++ b/backend/src/Handlers/RunStep.hs
@@ -59,10 +59,10 @@ runStepSync eid commit = do
                 (addDependencyRunningOverrides targetCommitText stepIds)
                 ( do
                     removeDependencyRunningOverrides targetCommitText stepIds
-                    mapM_ (`broadcastStatusForStepProjects` Nothing) stepIds
+                    mapM_ (\sid -> broadcastStatusForStepProjects sid targetCommitText Nothing) stepIds
                 )
                 ( do
-                    mapM_ (`broadcastStatusForStepProjects` Nothing) stepIds
+                    mapM_ (\sid -> broadcastStatusForStepProjects sid targetCommitText Nothing) stepIds
                     mapConcurrently_ (buildStep ctx) stepIds
                 )
 
@@ -116,13 +116,14 @@ buildStep ctx eid = do
 
         outPathText <- requireOutPathFromCache ctx eid
         let outPath = T.unpack outPathText
+        let targetCommitText = T.pack (readCommitHash ctx)
         built <- liftIO $ isBuilt outPath
         if built
-            then liftIO $ broadcastStatusForStepProjects eid Nothing
+            then liftIO $ broadcastStatusForStepProjects eid targetCommitText Nothing
             else do
                 let unitName = outPathToUnitName outPath
                 _ <- liftIO $ readProcessWithExitCodeL "systemctl" ["reset-failed", unitName] ""
-                liftIO $ broadcastStatusForStepProjects eid (Just ("running", Nothing))
+                liftIO $ broadcastStatusForStepProjects eid targetCommitText (Just ("running", Nothing))
                 _ <-
                     liftIO $
                         readProcessWithExitCodeL
@@ -139,7 +140,7 @@ buildStep ctx eid = do
                             )
                             ""
                 _ <- liftIO $ registerGcRootForOutPath outPath
-                liftIO $ broadcastStatusForStepProjects eid Nothing
+                liftIO $ broadcastStatusForStepProjects eid targetCommitText Nothing
 
     case result of
         Left err -> putStrLn $ "buildStep error: " ++ err
@@ -217,7 +218,7 @@ stopStepSync eid commit = do
                 let unitName = outPathToUnitName $ T.unpack outPathText
                 _ <- liftIO $ readProcessWithExitCodeL "systemctl" ["stop", unitName] ""
                 liftIO $ removeDependencyRunningOverrides targetCommit [eid]
-                liftIO $ broadcastStatusForStepProjects eid Nothing
+                liftIO $ broadcastStatusForStepProjects eid targetCommit Nothing
 
     case result of
         Left err -> putStrLn $ "stopStep error: " ++ err

--- a/backend/src/Handlers/StatusStream.hs
+++ b/backend/src/Handlers/StatusStream.hs
@@ -76,7 +76,7 @@ streamLoop projectId targetCommit previousStatuses heartbeatTick busChan = do
         threadDelay 500000
         busUpdates <- atomically $ drainTChan busChan
 
-        let mLatestSnapshot = find (\snapshot -> Bus.projectId snapshot == projectId) (reverse busUpdates)
+        let mLatestSnapshot = find (\snapshot -> Bus.projectId snapshot == projectId && Bus.commit snapshot == targetCommit) (reverse busUpdates)
 
         case mLatestSnapshot of
             Just snapshot -> do

--- a/backend/src/Handlers/Statuses.hs
+++ b/backend/src/Handlers/Statuses.hs
@@ -10,16 +10,18 @@ module Handlers.Statuses (
     removeDependencyRunningOverrides,
     broadcastProjectStatus,
     broadcastStatusForStepProjects,
+    forkBroadcastProjectStatusAtHead,
+    forkBroadcastStatusForStepProjectsAtHead,
 ) where
 
 import BuildLog (ResolvedLog (..), lastMeaningfulLine, resolveBuildLog)
 import Bus (broadcastSnapshot)
 import Control.Concurrent (forkIO)
+import Control.Monad (forM_, void)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM (TVar, atomically, modifyTVar', newTVarIO, readTVarIO)
 import Control.Exception (SomeException, catch)
-import Control.Monad (forM_)
-import Control.Monad.Except (ExceptT (..), runExceptT)
+import Control.Monad.Except (runExceptT)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (eitherDecode)
 import Data.List (foldl')
@@ -130,24 +132,19 @@ applyDependencyRunningOverrides targetCommit statuses = do
             sid
             acc
 
-broadcastProjectStatus :: Int -> Maybe (Int, (Text, Maybe Text)) -> IO ()
-broadcastProjectStatus pid mStatusOverride = do
-    result <- withReadRepoTransaction $ \(ReadRepoContext _ hash) -> ExceptT $ do
-        let targetCommit = pack hash
-        outPaths <- getProjectOutPaths pid targetCommit
-        stats <- getStatuses targetCommit outPaths
-        let finalStats = case mStatusOverride of
-                Just (sid, st) -> Map.insert sid st stats
-                Nothing -> stats
-        broadcastSnapshot pid finalStats outPaths
-        return $ Right ()
-    case result of
-        Left err -> putStrLn $ "Error broadcasting project status: " ++ err
-        Right _ -> return ()
+broadcastProjectStatus :: Int -> Text -> Maybe (Int, (Text, Maybe Text)) -> IO ()
+broadcastProjectStatus pid targetCommit mStatusOverride = do
+    outPaths <- getProjectOutPaths pid targetCommit
+    stats <- getStatuses targetCommit outPaths
+    let finalStats = case mStatusOverride of
+            Just (sid, st) -> Map.insert sid st stats
+            Nothing -> stats
+    broadcastSnapshot pid targetCommit finalStats outPaths
 
-broadcastStatusForStepProjects :: Int -> Maybe (Text, Maybe Text) -> IO ()
-broadcastStatusForStepProjects sid mStatusOverride = do
-    result <- withReadRepoTransaction $ \ctx -> do
+broadcastStatusForStepProjects :: Int -> Text -> Maybe (Text, Maybe Text) -> IO ()
+broadcastStatusForStepProjects sid targetCommit mStatusOverride = do
+    result <- withReadRepoTransaction $ \(ReadRepoContext repoPath _) -> do
+        let ctx = ReadRepoContext repoPath (unpack targetCommit)
         output <- runNixInRepo ctx ["eval", "--json"] "#pointy.projects"
         let decodeResult = eitherDecode (TLE.encodeUtf8 (TL.pack output)) :: Either String (Map String ProjectDef)
         case decodeResult of
@@ -157,11 +154,25 @@ broadcastStatusForStepProjects sid mStatusOverride = do
             Right projects -> do
                 let targetProjects = filter (projectContainsStep sid) (Map.elems projects)
                 liftIO $ forM_ targetProjects $ \p ->
-                    forkIO $ broadcastProjectStatus (projectDefId p) (fmap (sid,) mStatusOverride)
+                    forkIO $ broadcastProjectStatus (projectDefId p) targetCommit (fmap (sid,) mStatusOverride)
                 return ()
     case result of
         Left err -> putStrLn $ "Error broadcasting statuses for step " ++ show sid ++ ": " ++ err
         Right _ -> return ()
+
+forkBroadcastProjectStatusAtHead :: Int -> IO ()
+forkBroadcastProjectStatusAtHead pid = do
+    eHead <- withReadRepoTransaction $ \(ReadRepoContext _ hash) -> return (pack hash)
+    case eHead of
+        Left err -> putStrLn $ "forkBroadcastProjectStatusAtHead skipped: " ++ err
+        Right c -> void $ forkIO $ broadcastProjectStatus pid c Nothing
+
+forkBroadcastStatusForStepProjectsAtHead :: Int -> IO ()
+forkBroadcastStatusForStepProjectsAtHead sid = do
+    eHead <- withReadRepoTransaction $ \(ReadRepoContext _ hash) -> return (pack hash)
+    case eHead of
+        Left err -> putStrLn $ "forkBroadcastStatusForStepProjectsAtHead skipped: " ++ err
+        Right c -> void $ forkIO $ broadcastStatusForStepProjects sid c Nothing
 
 projectContainsStep :: Int -> ProjectDef -> Bool
 projectContainsStep sid p =

--- a/backend/src/Handlers/Steps.hs
+++ b/backend/src/Handlers/Steps.hs
@@ -2,7 +2,6 @@
 
 module Handlers.Steps (patchStepHandler, postStepHandler) where
 
-import Control.Concurrent (forkIO)
 import Control.Monad.Except (ExceptT (..), catchError)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Lazy as LBS
@@ -13,7 +12,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import Handlers.ProjectEntities (assignRecordToProject)
 import Handlers.Projects (evaluateJsonToNix)
-import Handlers.Statuses (broadcastProjectStatus, broadcastStatusForStepProjects)
+import Handlers.Statuses (forkBroadcastProjectStatusAtHead, forkBroadcastStatusForStepProjectsAtHead)
 import OutPaths (withWriteRepoTransaction)
 import ProcessLimiter (readProcessWithExitCodeL)
 import Servant (Handler, NoContent (..), throwError)
@@ -36,7 +35,7 @@ patchStepHandler stepId jsonBody = do
                 commitAndPushChanges ctx $ "Update step " ++ show stepId
             case result of
                 Right _ -> do
-                    _ <- liftIO $ forkIO $ broadcastStatusForStepProjects stepId Nothing
+                    liftIO $ forkBroadcastStatusForStepProjectsAtHead stepId
                     return NoContent
                 Left err -> throwError $ err400{errBody = TLE.encodeUtf8 (TL.pack err)}
 
@@ -60,9 +59,7 @@ postStepHandler maybeProjectId jsonBody = do
     case result of
         Right output -> do
             case maybeProjectId of
-                Just projectId -> do
-                    _ <- liftIO $ forkIO $ broadcastProjectStatus projectId Nothing
-                    return ()
+                Just projectId -> liftIO $ forkBroadcastProjectStatusAtHead projectId
                 Nothing -> return ()
             return output
         Left err -> throwError $ err400{errBody = TLE.encodeUtf8 (TL.pack err)}


### PR DESCRIPTION
Fixes #21 

SSE status stream cross-contaminated commits. Subscriber on old commit got snapshots whose payload was current-HEAD's project (different step set, different outPaths, override invisible because keyed by commit).

Cause: bus message had no commit field; broadcasters resolved HEAD via withReadRepoTransaction regardless of which commit triggered the action; stream loop filtered by projectId only.

Fix: ProjectSnapshot carries commit. broadcastProjectStatus and broadcastStatusForStepProjects take targetCommit explicitly. Run/stop/ build pass their target commit; CRUD passes branch HEAD via small forkBroadcast*AtHead helpers. Stream loop filters by (projectId, commit).