### PR TITLE
improve eval-error display for failed steps

### DIFF
--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -33,7 +33,8 @@ executable backend
                    Handlers.StatusStream,
                    Handlers.Upload,
                    Bus,
-                   NixUtils
+                   NixUtils,
+                   EvalError
     build-depends: base ^>=4.19.2.0,
                    stm,
                    async,

--- a/backend/src/EvalError.hs
+++ b/backend/src/EvalError.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Capture and cache @nix eval@ errors for step drv paths. Errors are
+-- parsed from Nix's @--log-format internal-json@ stream; the cache is
+-- keyed on @(commit, stepId)@ and never invalidated, since commits are
+-- immutable. A per-key empty 'MVar' acts as the single-flight latch.
+module EvalError (
+    EvalResult,
+    getCachedEvalError,
+    cachedEvalStepDrv,
+    kickEvalStepDrv,
+    cleanEvalError,
+    shortEvalError,
+) where
+
+import Control.Concurrent (forkIO)
+import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, readMVar, tryReadMVar)
+import Control.Concurrent.STM (TVar, atomically, modifyTVar', newTVarIO, readTVar, readTVarIO)
+import Control.Exception (SomeException, try)
+import Control.Monad (void, when)
+import Control.Monad.Except (runExceptT)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A
+import Data.Maybe (fromMaybe, mapMaybe)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import System.IO.Unsafe (unsafePerformIO)
+import UserRepo (ReadRepoContext (..), runNixInRepo)
+
+type EvalResult = Either Text Text
+
+{-# NOINLINE evalCache #-}
+evalCache :: TVar (Map.Map (Text, Int) (MVar EvalResult))
+evalCache = unsafePerformIO (newTVarIO Map.empty)
+
+getCachedEvalError :: Text -> Int -> IO (Maybe EvalResult)
+getCachedEvalError commit sid = do
+    m <- readTVarIO evalCache
+    maybe (pure Nothing) tryReadMVar (Map.lookup (commit, sid) m)
+
+cachedEvalStepDrv :: ReadRepoContext -> Int -> IO EvalResult
+cachedEvalStepDrv ctx sid = do
+    (mv, owns) <- claim (T.pack (readCommitHash ctx)) sid
+    if owns then fillEval ctx sid mv else readMVar mv
+
+kickEvalStepDrv :: ReadRepoContext -> Int -> (EvalResult -> IO ()) -> IO ()
+kickEvalStepDrv ctx sid onDone = do
+    (mv, owns) <- claim (T.pack (readCommitHash ctx)) sid
+    when owns . void . forkIO $ fillEval ctx sid mv >>= onDone
+
+-- | Atomically reserve the latch for @(commit, sid)@. The 'Bool' is
+-- 'True' iff the caller now owns the latch and must fill it.
+claim :: Text -> Int -> IO (MVar EvalResult, Bool)
+claim commit sid = do
+    fresh <- newEmptyMVar
+    atomically $ do
+        m <- readTVar evalCache
+        case Map.lookup (commit, sid) m of
+            Just existing -> pure (existing, False)
+            Nothing -> do
+                modifyTVar' evalCache (Map.insert (commit, sid) fresh)
+                pure (fresh, True)
+
+fillEval :: ReadRepoContext -> Int -> MVar EvalResult -> IO EvalResult
+fillEval ctx sid mv = do
+    attempt <- try (runEval ctx sid) :: IO (Either SomeException EvalResult)
+    let r = either (Left . T.pack . ("internal eval error: " <>) . show) id attempt
+    putMVar mv r
+    pure r
+
+runEval :: ReadRepoContext -> Int -> IO EvalResult
+runEval ctx sid =
+    bimap T.pack (T.strip . T.pack)
+        <$> runExceptT
+            ( runNixInRepo
+                ctx
+                ["eval", "--raw", "--show-trace", "--log-format", "internal-json"]
+                ("#pointy.steps." ++ show sid ++ ".drvPath")
+            )
+  where
+    bimap f g = either (Left . f) (Right . g)
+
+-- | The deepest @raw_msg@ from the error stream, suffixed with
+-- @\<repo-relative path\>:\<line\>@ when the envelope carries a location.
+shortEvalError :: Text -> Maybe Text
+shortEvalError t = do
+    ev <- lastError t
+    let bare = T.strip (stripAnsi (eeRawMsg ev))
+    pure (annotateLocation ev bare)
+
+-- | Full trace with ANSI removed, dedented, and pruned of frames that
+-- point at third-party Nix code (nixpkgs, dream2nix, the module
+-- system). The user-repo store path is inferred from the envelope
+-- @file@ and rewritten to a repo-relative path.
+cleanEvalError :: Text -> Text
+cleanEvalError t = case lastError t of
+    Nothing -> t
+    Just ev ->
+        let m = stripAnsi (eeMsg ev)
+         in case inferUserPrefix ev of
+                Nothing -> dedent m
+                Just up ->
+                    let blocks = T.splitOn "\n\n" m
+                        kept = filter (keepBlock up) blocks
+                        joined = T.intercalate "\n\n" (map (T.replace up "") kept)
+                     in dedent joined
+
+data ErrorEvent = ErrorEvent
+    { eeFile :: Maybe Text
+    , eeLine :: Maybe Int
+    , eeRawMsg :: Text
+    , eeMsg :: Text
+    }
+
+lastError :: Text -> Maybe ErrorEvent
+lastError = lastMay . mapMaybe parseLine . T.lines
+  where
+    parseLine line = do
+        payload <- T.stripPrefix "@nix " line
+        v <- A.decodeStrict (TE.encodeUtf8 payload)
+        A.parseMaybe pickError v
+    pickError = A.withObject "msg" $ \o -> do
+        action :: Text <- o A..: "action"
+        level :: Int <- o A..: "level"
+        if action == "msg" && level == 0
+            then
+                ErrorEvent
+                    <$> o A..:? "file"
+                    <*> o A..:? "line"
+                    <*> o A..: "raw_msg"
+                    <*> o A..: "msg"
+            else fail ""
+    lastMay [] = Nothing
+    lastMay xs = Just (last xs)
+
+-- | Store-path prefix Nix copied the user repo to. Whatever store path
+-- the envelope @file@ lives under is treated as user-repo; any other
+-- prefix is third-party.
+inferUserPrefix :: ErrorEvent -> Maybe Text
+inferUserPrefix ev = eeFile ev >>= storePathPrefix
+
+storePathPrefix :: Text -> Maybe Text
+storePathPrefix p = do
+    rest <- T.stripPrefix "/nix/store/" p
+    let (hash, after) = T.breakOn "/" rest
+    if T.null hash || not ("/" `T.isPrefixOf` after)
+        then Nothing
+        else Just ("/nix/store/" <> hash <> "/")
+
+annotateLocation :: ErrorEvent -> Text -> Text
+annotateLocation ev bare = case (eeFile ev >>= toRepoRelative, eeLine ev) of
+    (Just rel, Just ln) -> bare <> " (" <> rel <> ":" <> T.pack (show ln) <> ")"
+    _ -> bare
+
+toRepoRelative :: Text -> Maybe Text
+toRepoRelative fileLoc = do
+    rest <- T.stripPrefix "/nix/store/" fileLoc
+    let (_, after) = T.breakOn "/" rest
+    rest2 <- T.stripPrefix "/" after
+    pure (T.takeWhile (/= ':') rest2)
+
+keepBlock :: Text -> Text -> Bool
+keepBlock userPrefix block
+    | "(stack trace truncated" `T.isInfixOf` block = False
+    | "duplicate frames omitted)" `T.isInfixOf` block = False
+    | otherwise =
+        let paths = findStorePaths block
+            hasUser = any (userPrefix `T.isPrefixOf`) paths
+            hasOtherStore = any (not . (userPrefix `T.isPrefixOf`)) paths
+            hasBuiltinPath = "at <" `T.isInfixOf` block
+         in if hasUser
+                then True
+                else
+                    if hasOtherStore || hasBuiltinPath
+                        then False
+                        else not (isModuleSystemNoise block)
+
+findStorePaths :: Text -> [Text]
+findStorePaths = go
+  where
+    go t = case T.breakOn "/nix/store/" t of
+        (_, rest) | T.null rest -> []
+        (_, rest) ->
+            let path = T.takeWhile pathChar rest
+             in path : go (T.drop (T.length path) rest)
+    pathChar c = c /= '\n' && c /= ' ' && c /= '\'' && c /= '`' && c /= '"' && c /= ':'
+
+-- | A single-line frame containing only @while evaluating the option@
+-- or @while evaluating definitions from@. With its source-bearing
+-- companion frames already filtered out, it carries no useful info.
+isModuleSystemNoise :: Text -> Bool
+isModuleSystemNoise block =
+    let s = T.strip block
+     in not ("\n" `T.isInfixOf` s)
+            && ( "while evaluating the option" `T.isInfixOf` s
+                    || "while evaluating definitions from" `T.isInfixOf` s
+               )
+
+-- | Drop the 7-space indent Nix uses for trace frames. Source-snippet
+-- lines (11+ spaces) keep their relative alignment.
+dedent :: Text -> Text
+dedent t = T.unlines (map dropIndent (T.lines t))
+  where
+    dropIndent l = fromMaybe l (T.stripPrefix "       " l)
+
+stripAnsi :: Text -> Text
+stripAnsi t = case T.breakOn "\ESC[" t of
+    (before, rest) | T.null rest -> before
+    (before, rest) -> before <> stripAnsi (T.drop 1 (snd (T.breakOn "m" (T.drop 2 rest))))

--- a/backend/src/Handlers/RunStep.hs
+++ b/backend/src/Handlers/RunStep.hs
@@ -7,6 +7,7 @@ module Handlers.RunStep (
 ) where
 
 import BuildLog (LogSource (..), ResolvedLog (..), resolveBuildLog)
+import EvalError (cachedEvalStepDrv, cleanEvalError, getCachedEvalError, shortEvalError)
 import Cache (getOutPathFromCache, memoizeStepOutPaths)
 import Control.Concurrent (forkIO)
 import Control.Concurrent.Async (mapConcurrently_)
@@ -79,7 +80,16 @@ stepLogHandler eid commit = do
                     return (repoPath, maybe commitHash T.unpack commit)
 
         let ctx = ReadRepoContext repoPath targetCommit
-        liftIO $ resolveBuildLog (stepInstallable ctx eid)
+        mResolved <- liftIO $ resolveBuildLog (stepInstallable ctx eid)
+        case mResolved of
+            Just rl -> return (Just (renderResolvedLog rl))
+            Nothing -> do
+                mEvalErr <- liftIO $ getCachedEvalError (T.pack targetCommit) eid
+                case mEvalErr of
+                    Just (Left stderrTxt) -> do
+                        mSrc <- liftIO $ readStepSource repoPath targetCommit eid
+                        return (Just (renderEvalError eid mSrc (cleanEvalError stderrTxt)))
+                    _ -> return Nothing
 
     case result of
         Left err -> throwError $ err500{errBody = TLE.encodeUtf8 (TL.pack err)}
@@ -89,7 +99,7 @@ stepLogHandler eid commit = do
                     { errBody =
                         TLE.encodeUtf8 (TL.pack ("No build log available for step " ++ show eid))
                     }
-        Right (Just rl) -> return (renderResolvedLog rl)
+        Right (Just txt) -> return txt
 
 {- | Render a resolved log for the wire. Logs that come from an input
 derivation (rather than the step itself) are prefixed so the user knows
@@ -99,6 +109,29 @@ renderResolvedLog :: ResolvedLog -> T.Text
 renderResolvedLog (ResolvedLog _ logText StepDrv) = T.pack logText
 renderResolvedLog (ResolvedLog drv logText (InputDrv _ _)) =
     T.pack ("Build prerequisite failed: " ++ drv ++ "\n-----\n" ++ logText)
+
+-- | @git show <commit>:steps/<eid>.nix@. 'Nothing' iff the path does
+-- not exist at that revision or git exits non-zero.
+readStepSource :: FilePath -> String -> Int -> IO (Maybe T.Text)
+readStepSource repoPath targetCommit eid = do
+    let spec = targetCommit ++ ":steps/" ++ show eid ++ ".nix"
+    (ec, out, _) <-
+        readProcessWithExitCodeL "git" ["-C", repoPath, "show", spec] ""
+    case ec of
+        ExitSuccess -> return (Just (T.pack out))
+        _ -> return Nothing
+
+-- | Prepend the step's saved configuration (when available) to the
+-- cleaned eval-error trace.
+renderEvalError :: Int -> Maybe T.Text -> T.Text -> T.Text
+renderEvalError _ Nothing err = err
+renderEvalError eid (Just src) err =
+    "Step configuration (steps/"
+        <> T.pack (show eid)
+        <> ".nix):\n"
+        <> src
+        <> "\nError:\n"
+        <> err
 
 stepInstallable :: ReadRepoContext -> Int -> String
 stepInstallable (ReadRepoContext repoPath targetCommit) eid =
@@ -121,26 +154,35 @@ buildStep ctx eid = do
         if built
             then liftIO $ broadcastStatusForStepProjects eid targetCommitText Nothing
             else do
-                let unitName = outPathToUnitName outPath
-                _ <- liftIO $ readProcessWithExitCodeL "systemctl" ["reset-failed", unitName] ""
-                liftIO $ broadcastStatusForStepProjects eid targetCommitText (Just ("running", Nothing))
-                _ <-
-                    liftIO $
-                        readProcessWithExitCodeL
-                            "systemd-run"
-                            ( [ "--uid=backend"
-                              , "--gid=backend"
-                              , "--slice=pointy-builds.slice"
-                              , "--unit=" ++ unitName
-                              , "--collect"
-                              , "--wait"
-                              ]
-                                ++ pathEnvArg
-                                ++ ["nix", "build", "--no-link", "--no-eval-cache", stepInstallable ctx eid]
-                            )
-                            ""
-                _ <- liftIO $ registerGcRootForOutPath outPath
-                liftIO $ broadcastStatusForStepProjects eid targetCommitText Nothing
+                evalResult <- liftIO $ cachedEvalStepDrv ctx eid
+                case evalResult of
+                    Left stderrTxt ->
+                        liftIO $
+                            broadcastStatusForStepProjects
+                                eid
+                                targetCommitText
+                                (Just ("failure", shortEvalError stderrTxt))
+                    Right _ -> do
+                        let unitName = outPathToUnitName outPath
+                        _ <- liftIO $ readProcessWithExitCodeL "systemctl" ["reset-failed", unitName] ""
+                        liftIO $ broadcastStatusForStepProjects eid targetCommitText (Just ("running", Nothing))
+                        _ <-
+                            liftIO $
+                                readProcessWithExitCodeL
+                                    "systemd-run"
+                                    ( [ "--uid=backend"
+                                      , "--gid=backend"
+                                      , "--slice=pointy-builds.slice"
+                                      , "--unit=" ++ unitName
+                                      , "--collect"
+                                      , "--wait"
+                                      ]
+                                        ++ pathEnvArg
+                                        ++ ["nix", "build", "--no-link", "--no-eval-cache", stepInstallable ctx eid]
+                                    )
+                                    ""
+                        _ <- liftIO $ registerGcRootForOutPath outPath
+                        liftIO $ broadcastStatusForStepProjects eid targetCommitText Nothing
 
     case result of
         Left err -> putStrLn $ "buildStep error: " ++ err

--- a/backend/src/Handlers/Statuses.hs
+++ b/backend/src/Handlers/Statuses.hs
@@ -12,9 +12,11 @@ module Handlers.Statuses (
     broadcastStatusForStepProjects,
     forkBroadcastProjectStatusAtHead,
     forkBroadcastStatusForStepProjectsAtHead,
+    forkPrimeEvalErrorAtHead,
 ) where
 
 import BuildLog (ResolvedLog (..), lastMeaningfulLine, resolveBuildLog)
+import EvalError (getCachedEvalError, kickEvalStepDrv, shortEvalError)
 import Bus (broadcastSnapshot)
 import Control.Concurrent (forkIO)
 import Control.Monad (forM_, void)
@@ -27,7 +29,7 @@ import Data.Aeson (eitherDecode)
 import Data.List (foldl')
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Text (Text, pack, unpack)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
@@ -37,7 +39,7 @@ import Servant (Handler, throwError)
 import Servant.Server (err500, errBody)
 import System.Exit (ExitCode (..))
 import System.IO.Unsafe (unsafePerformIO)
-import UserRepo (ReadRepoContext (..), runNix, runNixInRepo, withReadRepoTransaction)
+import UserRepo (ReadRepoContext (..), runNix, runNixInRepo, userRepoPath, withReadRepoTransaction)
 
 {-# NOINLINE dependencyRunningOverrides #-}
 dependencyRunningOverrides :: TVar (Map (Text, Int) Int)
@@ -86,13 +88,41 @@ resolveFailure path fallback = do
 getStatuses :: Text -> Map Int Text -> IO (Map Int (Text, Maybe Text))
 getStatuses targetCommit outPaths = do
     rawStatuses <- Map.fromList <$> mapConcurrently getStatusForStep (Map.toList outPaths)
-    applyDependencyRunningOverrides targetCommit rawStatuses
+    withDeps <- applyDependencyRunningOverrides targetCommit rawStatuses
+    enrichWithEvalErrors targetCommit outPaths withDeps
   where
     getStatusForStep (sid, path) = do
         status_ <-
             checkStatus (unpack path)
                 `catch` \(_ :: SomeException) -> pure ("not-started", Nothing)
         pure (sid, status_)
+
+-- | Attach cached eval-error messages to invalid steps, kicking a
+-- background eval (and re-broadcast on failure) when no entry exists.
+enrichWithEvalErrors :: Text -> Map Int Text -> Map Int (Text, Maybe Text) -> IO (Map Int (Text, Maybe Text))
+enrichWithEvalErrors targetCommit outPaths statuses = do
+    repoPath <- userRepoPath
+    let ctx = ReadRepoContext repoPath (unpack targetCommit)
+    Map.fromList <$> mapM (enrich ctx) (Map.toList statuses)
+  where
+    enrich ctx (sid, current@(state, mMsg))
+        | not (eligible sid state mMsg) = pure (sid, current)
+        | otherwise = do
+            mCached <- getCachedEvalError targetCommit sid
+            case mCached of
+                Just (Left err) -> pure (sid, ("failure", shortEvalError err))
+                Just _ -> pure (sid, current)
+                Nothing -> do
+                    kickEvalStepDrv ctx sid (onKicked sid)
+                    pure (sid, current)
+
+    eligible sid state mMsg =
+        Map.findWithDefault "" sid outPaths == "/invalid"
+            && (state == "failure" || state == "not-started")
+            && isNothing mMsg
+
+    onKicked sid (Left _) = broadcastStatusForStepProjects sid targetCommit Nothing
+    onKicked _ _ = pure ()
 
 addDependencyRunningOverrides :: Text -> [Int] -> IO ()
 addDependencyRunningOverrides targetCommit stepIds =
@@ -173,6 +203,21 @@ forkBroadcastStatusForStepProjectsAtHead sid = do
     case eHead of
         Left err -> putStrLn $ "forkBroadcastStatusForStepProjectsAtHead skipped: " ++ err
         Right c -> void $ forkIO $ broadcastStatusForStepProjects sid c Nothing
+
+-- | Schedule a background eval for the step at HEAD; on failure the
+-- callback re-emits a snapshot so SSE consumers pick up the message.
+forkPrimeEvalErrorAtHead :: Int -> IO ()
+forkPrimeEvalErrorAtHead sid = do
+    eHead <- withReadRepoTransaction $ \(ReadRepoContext repoPath hash) ->
+        return (repoPath, pack hash)
+    case eHead of
+        Left err -> putStrLn $ "forkPrimeEvalErrorAtHead skipped: " ++ err
+        Right (repoPath, commitText) ->
+            let ctx = ReadRepoContext repoPath (unpack commitText)
+             in kickEvalStepDrv ctx sid (onPrimedEval commitText)
+  where
+    onPrimedEval c (Left _) = broadcastStatusForStepProjects sid c Nothing
+    onPrimedEval _ (Right _) = pure ()
 
 projectContainsStep :: Int -> ProjectDef -> Bool
 projectContainsStep sid p =

--- a/backend/src/Handlers/Steps.hs
+++ b/backend/src/Handlers/Steps.hs
@@ -12,7 +12,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import Handlers.ProjectEntities (assignRecordToProject)
 import Handlers.Projects (evaluateJsonToNix)
-import Handlers.Statuses (forkBroadcastProjectStatusAtHead, forkBroadcastStatusForStepProjectsAtHead)
+import Handlers.Statuses (forkBroadcastProjectStatusAtHead, forkBroadcastStatusForStepProjectsAtHead, forkPrimeEvalErrorAtHead)
 import OutPaths (withWriteRepoTransaction)
 import ProcessLimiter (readProcessWithExitCodeL)
 import Servant (Handler, NoContent (..), throwError)
@@ -36,6 +36,7 @@ patchStepHandler stepId jsonBody = do
             case result of
                 Right _ -> do
                     liftIO $ forkBroadcastStatusForStepProjectsAtHead stepId
+                    liftIO $ forkPrimeEvalErrorAtHead stepId
                     return NoContent
                 Left err -> throwError $ err400{errBody = TLE.encodeUtf8 (TL.pack err)}
 
@@ -55,12 +56,13 @@ postStepHandler maybeProjectId jsonBody = do
             case maybeProjectId of
                 Just projectId -> "Create step " ++ show stepId ++ " and assign to project " ++ show projectId
                 Nothing -> "Create step " ++ show stepId
-        return output
+        return (stepId, output)
     case result of
-        Right output -> do
+        Right (stepId, output) -> do
             case maybeProjectId of
                 Just projectId -> liftIO $ forkBroadcastProjectStatusAtHead projectId
                 Nothing -> return ()
+            liftIO $ forkPrimeEvalErrorAtHead stepId
             return output
         Left err -> throwError $ err400{errBody = TLE.encodeUtf8 (TL.pack err)}
 


### PR DESCRIPTION
Fixes #12 

before, a typo like `nixDeps = [ "cowsayy" ]` in a `script` template surfaced a tooltip of just `assertion '... hasAttrByPath ...' failed` and a popover whose first ~10 frames were nixpkgs / dream2nix scaffolding. user had no way to connect the failure to their input.

approach: ask nix for structured logs via
`--log-format internal-json --show-trace`. each error becomes one JSON event carrying `file`, `line`, `raw_msg`, and the full formatted trace. whatever `/nix/store/<HASH>-source/` path the envelope `file` lives in is by definition where the error fired, so treat that prefix as "user code" and every other store path (or `<builtin>`) as third-party.

EvalError:
- shortEvalError (tooltip): raw_msg, ANSI-stripped, suffixed with `(<repo-relative-path>:<line>)` from the envelope.
- cleanEvalError (popover): split the formatted msg on blank lines into frames; drop frames whose `at <path>` is third-party; drop bare `while evaluating the option ...` / `definitions from ...` / `(stack trace truncated)` / `(N duplicate frames omitted)` lines; rewrite the user prefix to repo-relative; dedent the 7-space frame indent.

RunStep.stepLogHandler: on eval-error logs, also
`git show <commit>:steps/<eid>.nix` and prepend the step's saved config to the trace. user sees their inputs next to the error.

result for the cowsayy typo:
- tooltip: `assertion ... failed (templates/script.nix:26)`
- popover: step config (`"cowsayy"` plainly visible) + 2 user-code frames (`name:` lambda at script.nix:22 + the assert at :26) + final error. ~9 noise frames gone.

generic: classification uses store-path provenance plus a few stable noise patterns. no template edits required — any user repo benefits the same way.

net: substantial UX win on misspelled-dep diagnosis. nix itself still cannot say "did you mean cowsay?" because that requires the template to use `acc.${k}` instead of `assert hasAttrByPath`, which is a template-author choice we deliberately do not touch.

<img width="815" height="558" alt="image" src="https://github.com/user-attachments/assets/f7b02618-2804-4e21-a549-efd406d68d67" />

