### PR TITLE
move clone action beside delete

### DIFF
--- a/frontend/src/Model/TableSpec.elm
+++ b/frontend/src/Model/TableSpec.elm
@@ -2,6 +2,7 @@ module Model.TableSpec exposing
     ( StepSpec
     , TableSpec(..)
     , getApiPath
+    , getCloneRecord
     , getDefaultRecord
     , getDescription
     , getDirectoryView
@@ -40,6 +41,7 @@ type TableSpec a
         , displayName : String
         , description : Maybe String
         , upsertRecord : TableSpec a -> Flow Model ()
+        , cloneRecord : TableSpec a -> a -> Flow Model ()
         }
 
 
@@ -113,3 +115,8 @@ getApiPath (TableSpec spec) =
 getUpsertRecord : TableSpec a -> Flow Model ()
 getUpsertRecord ((TableSpec spec) as ts) =
     spec.upsertRecord ts
+
+
+getCloneRecord : TableSpec a -> a -> Flow Model ()
+getCloneRecord ((TableSpec spec) as ts) =
+    spec.cloneRecord ts

--- a/frontend/src/Specs.elm
+++ b/frontend/src/Specs.elm
@@ -7,6 +7,7 @@ import Api.Decode as Decode
 import Api.Encode as Encode
 import Dict
 import Extra.Accessors exposing (where_)
+import Flow
 import Model.Core exposing (ProjectRecord, StepRecord, TableTag(..), initialTable)
 import Model.Lenses as Lenses exposing (currentTableOf)
 import Model.Shadow as Shadow exposing (StepConfig, StepConfigEntry, WithSrcFiles(..))
@@ -54,6 +55,7 @@ steps name entry =
         , description = entry.description
         , apiPath = "/step"
         , upsertRecord = Actions.upsertStep
+        , cloneRecord = Actions.cloneStep
         }
 
 
@@ -82,4 +84,5 @@ projects stepConfig =
         , description = Nothing
         , apiPath = "/projects"
         , upsertRecord = Actions.upsertProject
+        , cloneRecord = \_ _ -> Flow.none
         }

--- a/frontend/src/View/Shadow.elm
+++ b/frontend/src/View/Shadow.elm
@@ -139,35 +139,24 @@ viewSection model sectionName entry steps =
                             FileUpload _ ->
                                 []
 
-                    editActions =
+                    uploadActions =
                         if isReadOnly then
                             []
 
                         else
-                            let
-                                cloneActions =
-                                    if TableSpec.getShareable spec r then
-                                        [ viewIconButtonWithTooltip "content_copy" False "Clone" (Actions.cloneStep spec r) ]
-
-                                    else
-                                        []
-
-                                uploadActions =
-                                    case stepType of
-                                        FileUpload types ->
-                                            case r.id |> Maybe.andThen (\id -> Dict.get id (Model.getUploadProgress model) |> Maybe.map (Tuple.pair id)) of
-                                                Just _ ->
-                                                    []
-
-                                                Nothing ->
-                                                    [ Html.viewMaybe (viewUploadButton << Actions.uploadFiles spec (Maybe.withDefault [] types)) r.id ]
-
-                                        Derivation _ _ ->
+                            case stepType of
+                                FileUpload types ->
+                                    case r.id |> Maybe.andThen (\id -> Dict.get id (Model.getUploadProgress model) |> Maybe.map (Tuple.pair id)) of
+                                        Just _ ->
                                             []
-                            in
-                            cloneActions ++ uploadActions
+
+                                        Nothing ->
+                                            [ Html.viewMaybe (viewUploadButton << Actions.uploadFiles spec (Maybe.withDefault [] types)) r.id ]
+
+                                Derivation _ _ ->
+                                    []
                 in
-                editActions ++ runActions
+                uploadActions ++ runActions
         , directorySection = FileBrowser.viewDirectorySection model spec
         , srcFilesSection = FileBrowser.viewSrcFilesSection model stepType spec
         , onRecordClick =

--- a/frontend/src/View/Table.elm
+++ b/frontend/src/View/Table.elm
@@ -172,6 +172,10 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                             )
                             (Actions.toggleRecordVisibility spec mProjectId Nothing record)
               }
+            , -- Clone button (shareable only)
+              { shouldShow = \record -> not isReadOnly && TableSpec.getShareable spec record
+              , render = \record -> viewIconButtonWithTooltip "content_copy" False "Clone" (TableSpec.getCloneRecord spec record)
+              }
             , -- Remove button
               { shouldShow =
                     \record ->


### PR DESCRIPTION
clone and delete both mutate the set of rows. other actions (run, edit, inspect, share, hide) act on the existing row. group clone next to delete so primary actions get top slots.