### PR TITLE
mobile row layout

### DIFF
--- a/frontend/src/View/Table.elm
+++ b/frontend/src/View/Table.elm
@@ -337,6 +337,12 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                             [ class "record-name-container"
                             ]
                             [ Html.text record.name
+                            , Html.viewMaybe
+                                (\id_ ->
+                                    Html.span [ class "table-record-id", title <| "id: " ++ String.fromInt id_ ]
+                                        [ Html.text (String.fromInt id_) ]
+                                )
+                                record.id
                             , iconCustom True
                                 "edit"
                                 [ class "edit-icon"
@@ -351,6 +357,19 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
 
                         actionsContainerClass =
                             "table-record-actions-container"
+
+                        mtimeBadge =
+                            Html.viewMaybe
+                                (\posix ->
+                                    let iso = Iso8601.fromTime posix in
+                                    Html.node "time"
+                                        [ class "table-record-mtime"
+                                        , attribute "datetime" iso
+                                        , title ("Last modified: " ++ iso)
+                                        ]
+                                        [ Html.text (Time.Distance.inWords posix (Model.getNow model)) ]
+                                )
+                                record.lastModifiedAt
                     in
                     Html.div
                         ([ class "table-record", id itemId ] ++ attrs)
@@ -383,23 +402,7 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                                     viewStatusApiData (TableSpec.getStatus spec record)
                             , Html.span [ class "table-record-name" ]
                                 [ recordNameEditable
-                                , Html.viewMaybe
-                                    (\id_ ->
-                                        Html.span [ class "table-record-id", title <| "id: " ++ String.fromInt id_ ]
-                                            [ Html.text (String.fromInt id_) ]
-                                    )
-                                    record.id
-                                , Html.viewMaybe
-                                    (\posix ->
-                                        let iso = Iso8601.fromTime posix in
-                                        Html.node "time"
-                                            [ class "table-record-mtime"
-                                            , attribute "datetime" iso
-                                            , title ("Last modified: " ++ iso)
-                                            ]
-                                            [ Html.text (Time.Distance.inWords posix (Model.getNow model)) ]
-                                    )
-                                    record.lastModifiedAt
+                                , mtimeBadge
                                 , Html.viewIf (record.id == Nothing) <|
                                     Html.span [ class "pending-record-indicator", title "Saving..." ]
                                         [ iconCustom True "progress_activity" [ class "pending-record-icon" ]
@@ -439,6 +442,7 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                                 , Html.viewIf (not isReadOnly) <|
                                     Html.div (class "table-record-drag-target" :: List.map (map (Actions.dndMsgToIO mProjectId spec)) (mkTargetAttrs itemId))
                                         [ icon True "drag_indicator" ]
+                                , mtimeBadge
                                 ]
                             ]
                         , Html.viewIf (TableSpec.getSrcFilesView spec record |> Maybe.map .expanded |> Maybe.withDefault False) (srcFilesSection record)

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -171,12 +171,18 @@ body {
   border: 1px solid;
   color: var(--color-gray-500);
   padding-inline: var(--spacing-2xs);
+  margin-left: var(--spacing-sm);
 }
 
 .table-record-mtime {
   font-family: monospace;
   font-size: 10px;
   color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.table-record-actions-container .table-record-mtime {
+  display: none;
 }
 
 .pending-record-indicator {
@@ -271,6 +277,24 @@ body {
 
   .table-record-header .table-record-drag-target {
     display: none;
+  }
+
+  .table-record-header {
+    grid-template-columns: 32px 1fr auto;
+    column-gap: var(--spacing-sm);
+
+    &.no-status {
+      grid-template-columns: 1fr auto;
+    }
+  }
+
+  .table-record-name .table-record-mtime {
+    display: none;
+  }
+
+  .table-record-actions-container .table-record-mtime {
+    display: inline-flex;
+    order: -1;
   }
 
   .help-btn span:not(.material-symbols-outlined) {
@@ -943,6 +967,20 @@ $readonly-disabled-targets: (
   h2 {
     margin: 0;
     color: var(--text-primary);
+  }
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: stretch;
+
+    .select-container {
+      flex-basis: auto;
+      order: -1;
+    }
+
+    .select-container--right {
+      margin-left: 0;
+    }
   }
 }
 


### PR DESCRIPTION
<img width="1080" height="1448" alt="searchPosition" src="https://github.com/user-attachments/assets/bf3788e9-b297-4994-bc36-07d611810173" />

mobile (max-width: 600px):
- .table-record-mtime: white-space: nowrap so each
  relative-time badge stays on one line.
- .table-record-header: grid "32px 1fr auto" with
  column-gap so the action column shrinks to its
  content and the id badge no longer kisses the mtime.
- .page-header: flex-direction: column with align-
  items stretch; the global search sits on top at full
  width (.select-container ordered first; .select-
  container--right margin reset), title row below.
- mtime swaps out of the name flex into the actions
  container via CSS hide/show; order: -1 places it
  left of the hamburger; row height stays whatever
  the name dictates.

universal:
- id badge moves inline inside .record-name-container
  so it flows with the wrapping text instead of
  detaching at the right edge of column 2. margin-left
  replaces the lost flex gap.