### PR TITLE
combobox: tabindex=-1 on suggestions prevents wrong chip on suggestion click

### DIFF
--- a/frontend/src/Components/Combobox.elm
+++ b/frontend/src/Components/Combobox.elm
@@ -222,6 +222,7 @@ view config =
                                             , type_ "button"
                                             , class "list-field-suggestion"
                                             , classList [ ( "active", i == clampedIndex ) ]
+                                            , Html.Attributes.tabindex -1
                                             , Events.preventDefaultOn "mousedown"
                                                 (Decode.succeed ( config.onSelect item, True ))
                                             ]


### PR DESCRIPTION
Fixes #54 

Clicking a suggestion caused the input to immediately blur before Elm processed the mousedown's onSelect message. The blur handler fired first with the stale query text and called onCreate, creating a chip from whatever the user had typed rather than the clicked suggestion.

tabindex=-1 on suggestion buttons prevents them from receiving focus on click, so the input never blurs during selection. mousedown still fires and dispatches onSelect correctly, adding the intended chip.