### PR TITLE
Buffer step statuses arriving during project reload

### DIFF
--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -261,11 +261,36 @@ loadProjects =
                                         try (route << Route.project << mCommit << just) model
                                 in
                                 callApiMerge Model.updateProjectRecordList (projects << records) (Api.fetchProjects mCommit_ presets_ stepConfig_ |> Flow.map (Result.map sortProjects))
+                                    |> FlowError.foldResult (\_ -> replayStepStatusBuffer) (\_ -> Flow.pure ())
                             )
                 )
         )
         |> Flow.return ()
 
+
+replayStepStatusBuffer : Flow Model ()
+replayStepStatusBuffer =
+    Flow.get
+        |> Flow.andThen
+            (\model ->
+                let
+                    applyOne ( stepId, ( commit, status ) ) =
+                        Flow.over
+                            (projects << records << success << each << tables << values << records << success << by .id (Just stepId) << runState)
+                            (\rs ->
+                                let
+                                    current =
+                                        ApiData.withDefault { commit = commit, status = NotAsked, directoryView = { children = NotAsked, expanded = False, extras = NotAsked } } rs
+                                in
+                                Success { current | commit = commit, status = Success status }
+                            )
+                in
+                get stepStatusBuffer model
+                    |> Dict.toList
+                    |> List.map applyOne
+                    |> Flow.batchM
+                    |> Flow.seq (Flow.setAll stepStatusBuffer Dict.empty)
+            )
 
 loadUserRepoInfo : Flow Model ()
 loadUserRepoInfo =
@@ -1745,12 +1770,21 @@ updateStepStatus snapshotCommit stepId newStatus =
         defaultRunState =
             { commit = snapshotCommit, status = NotAsked, directoryView = { children = NotAsked, expanded = False, extras = NotAsked } }
     in
-    Flow.over stepRunState
-        (\rs ->
-            let
-                current =
-                    ApiData.withDefault defaultRunState rs
-            in
-            Success { current | commit = snapshotCommit, status = Success newStatus }
-        )
+    Flow.get
+        |> Flow.andThen
+            (\model ->
+                if has stepRunState model then
+                    Flow.over stepRunState
+                        (\rs ->
+                            let
+                                current =
+                                    ApiData.withDefault defaultRunState rs
+                            in
+                            Success { current | commit = snapshotCommit, status = Success newStatus }
+                        )
+                        |> Flow.seq (Flow.over stepStatusBuffer (Dict.remove stepId))
+
+                else
+                    Flow.over stepStatusBuffer (Dict.insert stepId ( snapshotCommit, newStatus ))
+            )
         |> Flow.seq (Flow.when (newStatus == StatusSuccess) (runAndClearStepStatusHook stepId))

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -185,6 +185,7 @@ type Model
         , stepLogs : Dict String (ApiData String)
         , notices : Dict String (ApiData (List Notice))
         , stepStatusHooks : Dict Int (Flow Model ())
+        , stepStatusBuffer : Dict Int ( String, Status )
         , autocomplete : Dict String AutocompleteState
         , autocompleteDebounce : Debounce.Debounce AutocompleteJob
         , gutterDrag : Maybe GutterDrag
@@ -448,6 +449,10 @@ getStepStatusHooks (Model model) =
     model.stepStatusHooks
 
 
+getStepStatusBuffer : Model -> Dict Int ( String, Status )
+getStepStatusBuffer (Model model) =
+    model.stepStatusBuffer
+
 getAutocomplete : Model -> Dict String AutocompleteState
 getAutocomplete (Model model) =
     model.autocomplete
@@ -536,6 +541,7 @@ initialModel key route flags =
         , notices = Dict.empty
         , uploadProgress = Dict.empty
         , stepStatusHooks = Dict.empty
+        , stepStatusBuffer = Dict.empty
         , autocomplete = Dict.empty
         , autocompleteDebounce = Debounce.init
         , gutterDrag = Nothing

--- a/frontend/src/Model/Lenses.elm
+++ b/frontend/src/Model/Lenses.elm
@@ -523,6 +523,11 @@ stepStatusHooks =
     lens ".stepStatusHooks" Model.getStepStatusHooks (\(Model m) hooks -> Model { m | stepStatusHooks = hooks })
 
 
+stepStatusBuffer : Lens ls Model (Dict Int ( String, Model.Status )) x y
+stepStatusBuffer =
+    lens ".stepStatusBuffer" Model.getStepStatusBuffer (\(Model m) buf -> Model { m | stepStatusBuffer = buf })
+
+
 gutterDrag : Lens ls Model (Maybe Model.GutterDrag) x y
 gutterDrag =
     lens ".gutterDrag" Model.getGutterDrag (\(Model m) drag -> Model { m | gutterDrag = drag })


### PR DESCRIPTION
Fixes #64 

When you add steps from another project, the frontend refetches the project list, which briefly puts the data into a loading state. During that window, status updates arriving from the server get silently dropped because the code can't find the target row. The fix buffers any status updates that arrive while the data is loading, then applies them once the reload finishes.