### PR TITLE
Show correct error-reporting for failed steps

### DIFF
--- a/backend/src/Handlers/RunStep.hs
+++ b/backend/src/Handlers/RunStep.hs
@@ -130,11 +130,7 @@ buildStep ctx eid = do
                             then liftIO $ registerGcRootForOutPath outPath
                             else return ()
                         liftIO $ broadcastSingleStepForProjects eid targetCommitText outPath
-                    -- The scheduler job is already gone when the status is
-                    -- re-checked, so checkStatus would report "not-started"
-                    -- and the dependency-running override (still held by
-                    -- runStepSync) would mask the failure as "running".
-                    -- The exit code is authoritative: broadcast the failure.
+                    ExitFailure _ ->
                         liftIO $ broadcastFailedStepForProjects eid targetCommitText
 
         -- Build extras derivation if present, independently of main step status.

--- a/backend/src/Handlers/RunStep.hs
+++ b/backend/src/Handlers/RunStep.hs
@@ -135,7 +135,6 @@ buildStep ctx eid = do
                     -- and the dependency-running override (still held by
                     -- runStepSync) would mask the failure as "running".
                     -- The exit code is authoritative: broadcast the failure.
-                    ExitFailure _ ->
                         liftIO $ broadcastFailedStepForProjects eid targetCommitText
 
         -- Build extras derivation if present, independently of main step status.

--- a/backend/src/Handlers/RunStep.hs
+++ b/backend/src/Handlers/RunStep.hs
@@ -20,7 +20,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
-import Handlers.Statuses (addDependencyRunningOverrides, broadcastKnownStepStatus, broadcastSingleStepForProjects, broadcastStatusForStepProjects, removeDependencyRunningOverrides)
+import Handlers.Statuses (addDependencyRunningOverrides, broadcastFailedStepForProjects, broadcastKnownStepStatus, broadcastSingleStepForProjects, broadcastStatusForStepProjects, removeDependencyRunningOverrides)
 import NixUtils (isValidStorePath)
 import OutPaths (warmProjectOutPathsForCommit)
 import ProcessLimiter (readProcessWithExitCodeL)
@@ -129,8 +129,14 @@ buildStep ctx eid = do
                         if nowBuilt
                             then liftIO $ registerGcRootForOutPath outPath
                             else return ()
-                    ExitFailure _ -> return ()
-                liftIO $ broadcastSingleStepForProjects eid targetCommitText outPath
+                        liftIO $ broadcastSingleStepForProjects eid targetCommitText outPath
+                    -- The scheduler job is already gone when the status is
+                    -- re-checked, so checkStatus would report "not-started"
+                    -- and the dependency-running override (still held by
+                    -- runStepSync) would mask the failure as "running".
+                    -- The exit code is authoritative: broadcast the failure.
+                    ExitFailure _ ->
+                        liftIO $ broadcastFailedStepForProjects eid targetCommitText
 
         -- Build extras derivation if present, independently of main step status.
         liftIO $ buildExtras ctx eid

--- a/backend/src/Handlers/Statuses.hs
+++ b/backend/src/Handlers/Statuses.hs
@@ -201,12 +201,6 @@ broadcastStatusForStepProjects sid targetCommit mStatusOverride =
     withStepProjects sid targetCommit $ \pid _ ->
         broadcastProjectStatus pid targetCommit (fmap (sid,) mStatusOverride)
 
-{- | Uses the already-known out-path rather than re-evaluating each project's step list.
-The raw status is refined via the build log *before* the dependency-running
-override is applied: a failed build whose scheduler job has already vanished
-reports @"not-started"@, and overriding that to @"running"@ first would mask
-the failure for good (the override removal never rebroadcasts).
--}
 broadcastSingleStepForProjects :: Int -> Text -> FilePath -> IO ()
 broadcastSingleStepForProjects sid targetCommit outPath = do
     rawStatus <- checkStatus outPath `catch` \(_ :: SomeException) -> pure ("not-started", Nothing)
@@ -220,9 +214,6 @@ broadcastSingleStepForProjects sid targetCommit outPath = do
                     else resolvedStatus
         broadcastSnapshot pid targetCommit (Map.singleton sid status)
 
-{- | Broadcast a known build failure for a step, refining the error message
-from the recorded build log when one is available.
--}
 broadcastFailedStepForProjects :: Int -> Text -> IO ()
 broadcastFailedStepForProjects sid targetCommit =
     withStepProjects sid targetCommit $ \pid ctx -> do

--- a/backend/src/Handlers/Statuses.hs
+++ b/backend/src/Handlers/Statuses.hs
@@ -12,6 +12,7 @@ module Handlers.Statuses (
     removeDependencyRunningOverrides,
     broadcastProjectStatus,
     broadcastSingleStepForProjects,
+    broadcastFailedStepForProjects,
     broadcastKnownStepStatus,
     broadcastStatusForStepProjects,
     forkBroadcastProjectStatusAtHead,
@@ -200,19 +201,33 @@ broadcastStatusForStepProjects sid targetCommit mStatusOverride =
     withStepProjects sid targetCommit $ \pid _ ->
         broadcastProjectStatus pid targetCommit (fmap (sid,) mStatusOverride)
 
--- | Uses the already-known out-path rather than re-evaluating each project's step list.
+{- | Uses the already-known out-path rather than re-evaluating each project's step list.
+The raw status is refined via the build log *before* the dependency-running
+override is applied: a failed build whose scheduler job has already vanished
+reports @"not-started"@, and overriding that to @"running"@ first would mask
+the failure for good (the override removal never rebroadcasts).
+-}
 broadcastSingleStepForProjects :: Int -> Text -> FilePath -> IO ()
 broadcastSingleStepForProjects sid targetCommit outPath = do
     rawStatus <- checkStatus outPath `catch` \(_ :: SomeException) -> pure ("not-started", Nothing)
-    overrides <- readTVarIO dependencyRunningOverrides
-    let count = Map.findWithDefault 0 (targetCommit, sid) overrides
-        status =
-            if count > 0 && fst rawStatus == "not-started"
-                then ("running", Nothing)
-                else rawStatus
     withStepProjects sid targetCommit $ \pid ctx -> do
-        (_, resolvedStatus) <- resolveStepStatus ctx (sid, status)
-        broadcastSnapshot pid targetCommit (Map.singleton sid resolvedStatus)
+        (_, resolvedStatus) <- resolveStepStatus ctx (sid, rawStatus)
+        overrides <- readTVarIO dependencyRunningOverrides
+        let count = Map.findWithDefault 0 (targetCommit, sid) overrides
+            status =
+                if count > 0 && fst resolvedStatus == "not-started"
+                    then ("running", Nothing)
+                    else resolvedStatus
+        broadcastSnapshot pid targetCommit (Map.singleton sid status)
+
+{- | Broadcast a known build failure for a step, refining the error message
+from the recorded build log when one is available.
+-}
+broadcastFailedStepForProjects :: Int -> Text -> IO ()
+broadcastFailedStepForProjects sid targetCommit =
+    withStepProjects sid targetCommit $ \pid ctx -> do
+        (_, status) <- resolveStepStatus ctx (sid, ("failure", Nothing))
+        broadcastSnapshot pid targetCommit (Map.singleton sid status)
 
 broadcastKnownStepStatus :: Int -> Text -> (Text, Maybe Text) -> IO ()
 broadcastKnownStepStatus sid targetCommit status =


### PR DESCRIPTION
Fixes #67 

When a step failed, the server checked its status by asking the job scheduler — but the scheduler had already forgotten the finished job, so the status looked like "not started", and a rule meant for steps waiting in a running batch converted that to "running". Since that was the last update ever sent to the browser, the UI stayed stuck on "Running". The fix: when a build exits with a failure, the server now reports "failure" directly (it already knows it failed), and the "show waiting steps as running" rule is only applied after checking the build log, so it can never hide a real failure.