### PR TITLE
Agent polish

### DIFF
--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -1825,10 +1825,6 @@ closeAgentTurnStream =
     callJs "closeAgentTurnStream" (\_ -> Encode.null) (Decode.succeed ()) ()
 
 
-updateAgentState : (Model.AgentState -> Model.AgentState) -> Flow Model ()
-updateAgentState fn =
-    Flow.modify (\(Model.Model m) -> Model.Model { m | agent = fn m.agent })
-
 agentChatId : String
 agentChatId =
     "agent-chat"
@@ -1846,7 +1842,7 @@ scrollAgentChatToBottom =
 
 setAgentSessions : ApiData (List Model.AgentSessionView) -> Flow Model ()
 setAgentSessions data =
-    updateAgentState (\agentState -> { agentState | sessions = data })
+    Flow.over agent (\agentState -> { agentState | sessions = data })
 
 
 setAgentSessionsLoading : Flow Model ()
@@ -1911,6 +1907,7 @@ persistedTranscript view =
     , String.concat (List.map .turnLog turns)
     )
 
+
 isChangesetLifecycleTurn : Model.AgentTurn -> Bool
 isChangesetLifecycleTurn turn =
     turn.turnPrompt == "Apply proposed changeset" || turn.turnPrompt == "Discard proposed changeset"
@@ -1939,6 +1936,7 @@ appendPersistedTurn turn entries =
                     |> List.filter (not << String.isEmpty)
         in
         List.foldl appendChatLine seeded logLines
+
 
 changesetFromLifecycleTurn : Model.AgentTurn -> Model.ChatChangeset
 changesetFromLifecycleTurn turn =
@@ -2069,7 +2067,7 @@ hydrateSelectedAgentSession =
             (\model ->
                 case Model.selectedSessionView (Model.getAgent model) of
                     Just view ->
-                        updateAgentState
+                        Flow.over agent
                             (\s ->
                                 if shouldKeepLiveTranscript view s then
                                     s
@@ -2101,7 +2099,7 @@ resumeSelectedAgentTurn =
                                     Flow.pure ()
 
                                 else
-                                    updateAgentState (\s -> { s | activeTurnStream = Just turnId })
+                                    Flow.over agent (\s -> { s | activeTurnStream = Just turnId })
                                         |> Flow.seq (Flow.async (listenAndProcessAgentTurn turnId))
                                         |> Flow.return ()
 
@@ -2120,7 +2118,7 @@ handleAgentSessionResult :
 handleAgentSessionResult selectOnSuccess result =
     case result of
         Ok view ->
-            updateAgentState
+            Flow.over agent
                 (\agentState ->
                     let
                         withView =
@@ -2130,7 +2128,7 @@ handleAgentSessionResult selectOnSuccess result =
                             if selectOnSuccess then
                                 { withView
                                     | selectedSessionId = Just view.session.sessionId
-                                    , isSidebarOpen = False
+                                    , isMobileSidebarOpen = False
                                 }
 
                             else
@@ -2172,7 +2170,7 @@ loadAgentSessions =
                                                 Nothing ->
                                                     case List.head views of
                                                         Just first ->
-                                                            updateAgentState
+                                                            Flow.over agent
                                                                 (\s -> { s | selectedSessionId = Just first.session.sessionId })
 
                                                         Nothing ->
@@ -2190,7 +2188,7 @@ loadAgentSessions =
 
 selectAgentSession : String -> Flow Model ()
 selectAgentSession sessionId =
-    updateAgentState
+    Flow.over agent
         (\s ->
             { s
                 | selectedSessionId = Just sessionId
@@ -2199,7 +2197,7 @@ selectAgentSession sessionId =
                 , chatEntries = []
                 , chunkBuffer = ""
                 , showRawLog = False
-                , isSidebarOpen = False
+                , isMobileSidebarOpen = False
                 , sessionNameEdit = Nothing
             }
         )
@@ -2216,30 +2214,29 @@ toggleAgentPanel =
                     nextOpen =
                         not (Model.getAgent model).isPanelOpen
                 in
-                updateAgentState (\s -> { s | isPanelOpen = nextOpen, isSidebarOpen = False })
+                Flow.over agent (\s -> { s | isPanelOpen = nextOpen, isMobileSidebarOpen = False })
                     |> Flow.seq (Flow.when nextOpen loadAgentSessions)
             )
 
 
-
-toggleAgentSidebar : Flow Model ()
-toggleAgentSidebar =
-    updateAgentState (\s -> { s | isSidebarOpen = not s.isSidebarOpen })
+toggleAgentMobileSidebar : Flow Model ()
+toggleAgentMobileSidebar =
+    Flow.over agent (\s -> { s | isMobileSidebarOpen = not s.isMobileSidebarOpen })
 
 
 toggleAgentMaximized : Flow Model ()
 toggleAgentMaximized =
-    updateAgentState (\s -> { s | isMaximized = not s.isMaximized })
+    Flow.over agent (\s -> { s | isMaximized = not s.isMaximized })
 
 
-toggleAgentSidebarCollapsed : Flow Model ()
-toggleAgentSidebarCollapsed =
-    updateAgentState (\s -> { s | isSidebarCollapsed = not s.isSidebarCollapsed })
+toggleAgentDesktopSidebarCollapsed : Flow Model ()
+toggleAgentDesktopSidebarCollapsed =
+    Flow.over agent (\s -> { s | isDesktopSidebarCollapsed = not s.isDesktopSidebarCollapsed })
 
 
 startAgentSessionNameEdit : String -> String -> Flow Model ()
 startAgentSessionNameEdit sessionId currentName =
-    updateAgentState
+    Flow.over agent
         (\s ->
             { s
                 | sessionNameEdit =
@@ -2254,7 +2251,7 @@ startAgentSessionNameEdit sessionId currentName =
 
 updateAgentSessionNameEdit : String -> Flow Model ()
 updateAgentSessionNameEdit value =
-    updateAgentState
+    Flow.over agent
         (\s ->
             { s
                 | sessionNameEdit =
@@ -2265,7 +2262,7 @@ updateAgentSessionNameEdit value =
 
 cancelAgentSessionNameEdit : Flow Model ()
 cancelAgentSessionNameEdit =
-    updateAgentState (\s -> { s | sessionNameEdit = Nothing })
+    Flow.over agent (\s -> { s | sessionNameEdit = Nothing })
 
 
 saveAgentSessionName : Flow Model ()
@@ -2286,7 +2283,7 @@ saveAgentSessionName =
                             addToast False "Enter a chat name first."
 
                         else
-                            updateAgentState (setSessionNameEditSaving edit.sessionId True)
+                            Flow.over agent (setSessionNameEditSaving edit.sessionId True)
                                 |> Flow.seq
                                     (AgentApi.renameSession edit.sessionId name
                                         |> Flow.andThen
@@ -2294,10 +2291,10 @@ saveAgentSessionName =
                                                 case result of
                                                     Ok view ->
                                                         handleAgentSessionResult False (Ok view)
-                                                            |> Flow.seq (updateAgentState (clearSessionNameEdit edit.sessionId))
+                                                            |> Flow.seq (Flow.over agent (clearSessionNameEdit edit.sessionId))
 
                                                     Err err ->
-                                                        updateAgentState (setSessionNameEditSaving edit.sessionId False)
+                                                        Flow.over agent (setSessionNameEditSaving edit.sessionId False)
                                                             |> Flow.seq (addToast False (Http.errorMessage err))
                                             )
                                     )
@@ -2331,6 +2328,7 @@ clearSessionNameEdit sessionId agentState =
         Nothing ->
             agentState
 
+
 archiveAgentSession : String -> Flow Model ()
 archiveAgentSession sessionId =
     AgentApi.archive sessionId
@@ -2340,7 +2338,7 @@ archiveAgentSession sessionId =
                 |> Flow.andThen
                     (\model ->
                         if (Model.getAgent model).selectedSessionId == Just sessionId then
-                            updateAgentState
+                            Flow.over agent
                                 (\s ->
                                     { s
                                         | selectedSessionId = Nothing
@@ -2364,7 +2362,7 @@ deleteAgentSession sessionId =
             (\result ->
                 case result of
                     Ok () ->
-                        updateAgentState
+                        Flow.over agent
                             (\s ->
                                 let
                                     remaining =
@@ -2434,27 +2432,27 @@ confirmDeleteAgentSession sessionId =
 
 toggleAgentArchived : Flow Model ()
 toggleAgentArchived =
-    updateAgentState (\s -> { s | showArchived = not s.showArchived })
+    Flow.over agent (\s -> { s | showArchived = not s.showArchived })
 
 
 toggleAgentLog : Flow Model ()
 toggleAgentLog =
-    updateAgentState (\agentState -> { agentState | showRawLog = not agentState.showRawLog })
+    Flow.over agent (\agentState -> { agentState | showRawLog = not agentState.showRawLog })
 
 
 updateAgentPrompt : String -> Flow Model ()
 updateAgentPrompt prompt =
-    updateAgentState (\agentState -> { agentState | prompt = prompt })
+    Flow.over agent (\agentState -> { agentState | prompt = prompt })
 
 
 setChangesetOperation : String -> Model.ChangesetOperationKind -> Flow Model ()
 setChangesetOperation sessionId kind =
-    updateAgentState (\agentState -> { agentState | changesetOperation = Just { sessionId = sessionId, kind = kind } })
+    Flow.over agent (\agentState -> { agentState | changesetOperation = Just { sessionId = sessionId, kind = kind } })
 
 
 clearChangesetOperation : String -> Flow Model ()
 clearChangesetOperation sessionId =
-    updateAgentState
+    Flow.over agent
         (\agentState ->
             case agentState.changesetOperation of
                 Just operation ->
@@ -2515,7 +2513,7 @@ submitAgentPrompt =
                                     (\result ->
                                         case result of
                                             Ok turn ->
-                                                updateAgentState
+                                                Flow.over agent
                                                     (\agentState ->
                                                         { agentState
                                                             | prompt = ""
@@ -2628,14 +2626,14 @@ onAgentTurnIn : Decode.Value -> Flow Model ()
 onAgentTurnIn value =
     case Decode.decodeValue AgentApi.turnEvent value of
         Ok (Model.AgentTurnChunk { turnId, chunk }) ->
-            withActiveAgentTurn turnId (updateAgentState (ingestAgentChunk chunk) |> Flow.seq scrollAgentChatToBottom)
+            withActiveAgentTurn turnId (Flow.over agent (ingestAgentChunk chunk) |> Flow.seq scrollAgentChatToBottom)
 
         Ok (Model.AgentTurnDone turnId) ->
             withActiveAgentTurn turnId
-                (updateAgentState (finalizeChatTurn Nothing)
+                (Flow.over agent (finalizeChatTurn Nothing)
                     |> Flow.seq scrollAgentChatToBottom
                     |> Flow.seq
-                        (updateAgentState (\agentState -> { agentState | activeTurnStream = Nothing }))
+                        (Flow.over agent (\agentState -> { agentState | activeTurnStream = Nothing }))
                     |> Flow.seq
                         (Flow.get
                             |> Flow.andThen
@@ -2654,7 +2652,7 @@ onAgentTurnIn value =
             Flow.pure ()
 
         Ok (Model.AgentTurnError err) ->
-            updateAgentState (finalizeChatTurn (Just err))
+            Flow.over agent (finalizeChatTurn (Just err))
                 |> Flow.seq scrollAgentChatToBottom
                 |> Flow.seq (addToast False err)
 
@@ -2742,7 +2740,7 @@ splitLogPrefix line =
 appendToCurrentAssistant : String -> List Model.ChatEntry -> List Model.ChatEntry
 appendToCurrentAssistant body entries =
     case List.reverse entries of
-        Model.ChatTurnEntry last :: rest ->
+        (Model.ChatTurnEntry last) :: rest ->
             let
                 separator =
                     if String.isEmpty last.assistant then
@@ -2772,7 +2770,7 @@ finalizeChatTurn mError agentState =
                 ingestAgentChunk "\n" agentState
     in
     case List.reverse flushed.chatEntries of
-        Model.ChatTurnEntry last :: rest ->
+        (Model.ChatTurnEntry last) :: rest ->
             let
                 status =
                     case mError of

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -328,6 +328,15 @@ loadPresets =
         |> Flow.return ()
 
 
+reloadWorkspaceData : Flow Model ()
+reloadWorkspaceData =
+    Flow.over (projects << records) ApiData.toLoading
+        |> Flow.seq (Flow.over commitHash ApiData.toLoading)
+        |> Flow.seq loadStepConfig
+        |> Flow.seq loadPresets
+        |> Flow.seq loadProjects
+
+
 chooseProjectPreset : String -> Flow Model ()
 chooseProjectPreset =
     Flow.setAll (projects << edited << just << templateSource) << FromPreset
@@ -2551,6 +2560,7 @@ applyAgentChanges =
                                                             case confirmResult of
                                                                 Ok appliedView ->
                                                                     handleAgentSessionResult False (Ok appliedView)
+                                                                        |> Flow.seq reloadWorkspaceData
                                                                         |> Flow.seq loadAgentSessions
                                                                         |> Flow.seq (clearChangesetOperation view.session.sessionId)
 

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -2218,6 +2218,16 @@ toggleAgentSidebar =
     updateAgentState (\s -> { s | isSidebarOpen = not s.isSidebarOpen })
 
 
+toggleAgentMaximized : Flow Model ()
+toggleAgentMaximized =
+    updateAgentState (\s -> { s | isMaximized = not s.isMaximized })
+
+
+toggleAgentSidebarCollapsed : Flow Model ()
+toggleAgentSidebarCollapsed =
+    updateAgentState (\s -> { s | isSidebarCollapsed = not s.isSidebarCollapsed })
+
+
 startAgentSessionNameEdit : String -> String -> Flow Model ()
 startAgentSessionNameEdit sessionId currentName =
     updateAgentState

--- a/frontend/src/Api/Agent.elm
+++ b/frontend/src/Api/Agent.elm
@@ -88,6 +88,7 @@ discardSession : String -> Flow s (Result Http.Error Model.AgentSessionView)
 discardSession sessionId =
     postSessionView "/discard" (sessionIdBody sessionId)
 
+
 renameSession : String -> String -> Flow s (Result Http.Error Model.AgentSessionView)
 renameSession sessionId name =
     postSessionView "/rename"
@@ -96,7 +97,6 @@ renameSession sessionId name =
             , ( "name", Encode.string name )
             ]
         )
-
 
 
 postSessionView : String -> Encode.Value -> Flow s (Result Http.Error Model.AgentSessionView)

--- a/frontend/src/Components/AgentPanel.elm
+++ b/frontend/src/Components/AgentPanel.elm
@@ -5,7 +5,7 @@ import Api.ApiData as ApiData exposing (ApiData(..))
 import Extra.Http as Http
 import Flow exposing (Flow)
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, disabled, id, placeholder, rows, title, type_, value)
+import Html.Attributes exposing (attribute, class, classList, disabled, id, placeholder, title, type_, value)
 import Html.Events as Events
 import Json.Decode as Decode
 import Keyboard
@@ -39,12 +39,34 @@ view model =
 
 viewPanel : Model.AgentState -> Html (Flow Model ())
 viewPanel agent =
-    Html.div [ class "agent-panel" ]
+    Html.div [ classList [ ( "agent-panel", True ), ( "is-maximized", agent.isMaximized ) ] ]
         [ Html.div [ class "agent-panel__header" ]
             [ Html.div []
                 [ Html.h2 [] [ Html.text "AI agent" ]
                 ]
-            , Html.button [ class "icon-btn", Events.onClick Actions.toggleAgentPanel, title "Close agent panel" ] [ View.Icons.icon False "close" ]
+            , Html.div [ class "agent-panel__header-actions" ]
+                [ Html.button [ class "icon-btn", Events.onClick Actions.toggleAgentPanel, title "Minimize agent panel" ] [ View.Icons.icon False "minimize" ]
+                , Html.button
+                    [ class "icon-btn"
+                    , Events.onClick Actions.toggleAgentMaximized
+                    , title
+                        (if agent.isMaximized then
+                            "Restore agent panel"
+
+                         else
+                            "Maximize agent panel"
+                        )
+                    ]
+                    [ View.Icons.icon False
+                        (if agent.isMaximized then
+                            "close_fullscreen"
+
+                         else
+                            "open_in_full"
+                        )
+                    ]
+                , Html.button [ class "icon-btn", Events.onClick Actions.toggleAgentPanel, title "Close agent panel" ] [ View.Icons.icon False "close" ]
+                ]
             ]
         , viewSessionBody agent
         ]
@@ -56,7 +78,7 @@ viewSessionBody agent =
         loaded =
             ApiData.withDefault [] agent.sessions
     in
-    Html.div [ class "agent-panel__split" ]
+    Html.div [ classList [ ( "agent-panel__split", True ), ( "is-sidebar-collapsed", agent.isSidebarCollapsed ) ] ]
         [ viewSessionSidebar agent loaded
         , viewSessionDetail agent loaded
         ]
@@ -70,7 +92,18 @@ viewSessionSidebar agent loaded =
             , ( "is-open", agent.isSidebarOpen )
             ]
         ]
-        [ Html.button
+        [ Html.div [ class "agent-panel__sidebar-header" ]
+            [ Html.h3 [] [ Html.text "Chats" ]
+            , Html.button
+                [ class "agent-panel__new-chat"
+                , Events.onClick Actions.createAgentSession
+                , title "New chat"
+                ]
+                [ View.Icons.icon False "add"
+                , Html.span [] [ Html.text "New chat" ]
+                ]
+            ]
+        , Html.button
             [ class "agent-panel__sidebar-toggle"
             , Events.onClick Actions.toggleAgentSidebar
             , attribute "aria-controls" "agent-panel-sidebar-content"
@@ -88,6 +121,25 @@ viewSessionSidebar agent loaded =
             , id "agent-panel-sidebar-content"
             ]
             (viewSessionSidebarContent agent loaded)
+        , Html.button
+            [ class "icon-btn agent-panel__sidebar-collapse"
+            , Events.onClick Actions.toggleAgentSidebarCollapsed
+            , title
+                (if agent.isSidebarCollapsed then
+                    "Show chats"
+
+                 else
+                    "Hide chats"
+                )
+            ]
+            [ View.Icons.icon False
+                (if agent.isSidebarCollapsed then
+                    "left_panel_open"
+
+                 else
+                    "left_panel_close"
+                )
+            ]
         ]
 
 
@@ -115,11 +167,7 @@ viewSessionSidebarContent agent loaded =
             else
                 []
     in
-    [ Html.div [ class "agent-panel__sidebar-header" ]
-        [ Html.h3 [] [ Html.text "Chats" ]
-        , Html.button [ class "primary-btn", Events.onClick Actions.createAgentSession ] [ Html.text "New chat" ]
-        ]
-    , case listingStatus of
+    [ case listingStatus of
         Just msg ->
             Html.p [ class "agent-panel__loading" ] [ Html.text msg ]
 
@@ -300,21 +348,6 @@ viewSession agent sessionView =
         closedChat =
             isArchivedStatus session.status
 
-        hasChangesetBox =
-            pendingChangeset sessionView /= Nothing || hasChangesetLifecycleTurn sessionView.turns
-
-        activeOperation =
-            activeChangesetOperation agent session.sessionId
-
-        actionRunning =
-            activeOperation /= Nothing
-
-        discardChatLabel =
-            if activeOperation == Just Model.DiscardingChangeset then
-                "Discarding chat..."
-
-            else
-                "Discard chat"
     in
     Html.div [ class "agent-panel__body" ]
         [ viewSessionTitle agent sessionView
@@ -325,21 +358,6 @@ viewSession agent sessionView =
 
           else
             viewPrompt agent runnerActive
-        , Html.div [ class "agent-panel__footer" ]
-            ([ Html.button [ class "secondary-btn", Events.onClick (Actions.loadAgentSession session.sessionId) ] [ Html.text "Refresh" ] ]
-                ++ (if closedChat || hasChangesetBox then
-                        []
-
-                    else
-                        [ Html.button
-                            [ class "danger-btn"
-                            , disabled (runnerActive || actionRunning)
-                            , Events.onClick Actions.discardAgentSession
-                            ]
-                            [ Html.text discardChatLabel ]
-                        ]
-                   )
-            )
         ]
 
 
@@ -500,11 +518,9 @@ viewPrompt agent runnerActive =
         , Html.div [ class "agent-panel__composer-row" ]
             [ Html.textarea
                 [ class "agent-panel__prompt"
-                , rows 3
                 , value agent.prompt
                 , placeholder "Ask for a change..."
                 , disabled runnerActive
-                , attribute "data-auto-resize" "true"
                 , attribute "aria-label" "Agent prompt"
                 , submitShortcut runnerActive
                 , Events.onInput Actions.updateAgentPrompt
@@ -760,16 +776,6 @@ pendingChangeset sessionView =
 
     else
         Nothing
-
-
-hasChangesetLifecycleTurn : List Model.AgentTurn -> Bool
-hasChangesetLifecycleTurn turns =
-    hasLifecycleTurn "Apply proposed changeset" turns || hasLifecycleTurn "Discard proposed changeset" turns
-
-
-hasLifecycleTurn : String -> List Model.AgentTurn -> Bool
-hasLifecycleTurn prompt turns =
-    List.any (\turn -> turn.turnPrompt == prompt) turns
 
 
 defaultChangesetDescription : Model.ChatChangesetState -> String

--- a/frontend/src/Components/AgentPanel.elm
+++ b/frontend/src/Components/AgentPanel.elm
@@ -78,7 +78,7 @@ viewSessionBody agent =
         loaded =
             ApiData.withDefault [] agent.sessions
     in
-    Html.div [ classList [ ( "agent-panel__split", True ), ( "is-sidebar-collapsed", agent.isSidebarCollapsed ) ] ]
+    Html.div [ classList [ ( "agent-panel__split", True ), ( "is-desktop-sidebar-collapsed", agent.isDesktopSidebarCollapsed ) ] ]
         [ viewSessionSidebar agent loaded
         , viewSessionDetail agent loaded
         ]
@@ -89,7 +89,7 @@ viewSessionSidebar agent loaded =
     Html.div
         [ classList
             [ ( "agent-panel__sidebar", True )
-            , ( "is-open", agent.isSidebarOpen )
+            , ( "is-mobile-sidebar-open", agent.isMobileSidebarOpen )
             ]
         ]
         [ Html.div [ class "agent-panel__sidebar-header" ]
@@ -105,10 +105,10 @@ viewSessionSidebar agent loaded =
             ]
         , Html.button
             [ class "agent-panel__sidebar-toggle"
-            , Events.onClick Actions.toggleAgentSidebar
+            , Events.onClick Actions.toggleAgentMobileSidebar
             , attribute "aria-controls" "agent-panel-sidebar-content"
             , attribute "aria-expanded"
-                (if agent.isSidebarOpen then
+                (if agent.isMobileSidebarOpen then
                     "true"
 
                  else
@@ -123,9 +123,9 @@ viewSessionSidebar agent loaded =
             (viewSessionSidebarContent agent loaded)
         , Html.button
             [ class "icon-btn agent-panel__sidebar-collapse"
-            , Events.onClick Actions.toggleAgentSidebarCollapsed
+            , Events.onClick Actions.toggleAgentDesktopSidebarCollapsed
             , title
-                (if agent.isSidebarCollapsed then
+                (if agent.isDesktopSidebarCollapsed then
                     "Show chats"
 
                  else
@@ -133,7 +133,7 @@ viewSessionSidebar agent loaded =
                 )
             ]
             [ View.Icons.icon False
-                (if agent.isSidebarCollapsed then
+                (if agent.isDesktopSidebarCollapsed then
                     "left_panel_open"
 
                  else
@@ -347,7 +347,6 @@ viewSession agent sessionView =
 
         closedChat =
             isArchivedStatus session.status
-
     in
     Html.div [ class "agent-panel__body" ]
         [ viewSessionTitle agent sessionView

--- a/frontend/src/Components/Select.elm
+++ b/frontend/src/Components/Select.elm
@@ -64,7 +64,6 @@ matchesOrderedTokens query haystack =
     findTokens (List.filter (not << String.isEmpty) (String.words (String.toLower query))) (String.toLower haystack)
 
 
-
 type ChipAction
     = ChipClick
     | ChipRemove

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -245,6 +245,8 @@ type alias AgentState =
     , prompt : String
     , isPanelOpen : Bool
     , isSidebarOpen : Bool
+    , isMaximized : Bool
+    , isSidebarCollapsed : Bool
     , activeTurnStream : Maybe String
     , chatEntries : List ChatEntry
     , chunkBuffer : String
@@ -263,6 +265,8 @@ initAgentState =
     , prompt = ""
     , isPanelOpen = False
     , isSidebarOpen = False
+    , isMaximized = False
+    , isSidebarCollapsed = False
     , activeTurnStream = Nothing
     , chatEntries = []
     , chunkBuffer = ""

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -202,6 +202,7 @@ type alias ChatTurn =
     , status : ChatTurnStatus
     }
 
+
 type ChatChangesetState
     = ChatChangesetProposed
     | ChatChangesetNeedsReview String
@@ -220,6 +221,7 @@ type ChatEntry
     = ChatTurnEntry ChatTurn
     | ChatChangesetEntry ChatChangeset
 
+
 type ChangesetOperationKind
     = ApplyingChangeset
     | DiscardingChangeset
@@ -230,6 +232,7 @@ type alias ChangesetOperation =
     , kind : ChangesetOperationKind
     }
 
+
 type alias AgentSessionNameEdit =
     { sessionId : String
     , value : String
@@ -237,16 +240,14 @@ type alias AgentSessionNameEdit =
     }
 
 
-
-
 type alias AgentState =
     { sessions : ApiData (List AgentSessionView)
     , selectedSessionId : Maybe String
     , prompt : String
     , isPanelOpen : Bool
-    , isSidebarOpen : Bool
+    , isMobileSidebarOpen : Bool
     , isMaximized : Bool
-    , isSidebarCollapsed : Bool
+    , isDesktopSidebarCollapsed : Bool
     , activeTurnStream : Maybe String
     , chatEntries : List ChatEntry
     , chunkBuffer : String
@@ -264,9 +265,9 @@ initAgentState =
     , selectedSessionId = Nothing
     , prompt = ""
     , isPanelOpen = False
-    , isSidebarOpen = False
+    , isMobileSidebarOpen = False
     , isMaximized = False
-    , isSidebarCollapsed = False
+    , isDesktopSidebarCollapsed = False
     , activeTurnStream = Nothing
     , chatEntries = []
     , chunkBuffer = ""

--- a/frontend/styles/components/_agent-panel.scss
+++ b/frontend/styles/components/_agent-panel.scss
@@ -217,35 +217,36 @@
   flex: 1;
 }
 
-.agent-panel__split.is-sidebar-collapsed {
-  grid-template-columns: 44px 1fr;
-}
+@media (min-width: 701px) {
+  .agent-panel__split.is-desktop-sidebar-collapsed {
+    grid-template-columns: 44px 1fr;
+  }
 
-.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar {
-  align-items: center;
-  padding: var(--spacing-sm) 0;
-}
+  .agent-panel__split.is-desktop-sidebar-collapsed .agent-panel__sidebar {
+    align-items: center;
+    padding: var(--spacing-sm) 0;
+  }
 
-.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar-content {
-  display: none;
-}
+  .agent-panel__split.is-desktop-sidebar-collapsed .agent-panel__sidebar-content {
+    display: none;
+  }
 
+  .agent-panel__split.is-desktop-sidebar-collapsed .agent-panel__sidebar-header {
+    justify-content: center;
+    padding: 0;
+  }
 
-.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar-header {
-  justify-content: center;
-  padding: 0;
-}
+  .agent-panel__split.is-desktop-sidebar-collapsed .agent-panel__sidebar-header h3 {
+    display: none;
+  }
 
-.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar-header h3 {
-  display: none;
-}
+  .agent-panel__split.is-desktop-sidebar-collapsed .agent-panel__new-chat {
+    padding-inline: var(--spacing-xs);
+  }
 
-.agent-panel__split.is-sidebar-collapsed .agent-panel__new-chat {
-  padding-inline: var(--spacing-xs);
-}
-
-.agent-panel__split.is-sidebar-collapsed .agent-panel__new-chat span:not(.material-symbols-outlined) {
-  display: none;
+  .agent-panel__split.is-desktop-sidebar-collapsed .agent-panel__new-chat span:not(.material-symbols-outlined) {
+    display: none;
+  }
 }
 
 .agent-panel__body,
@@ -872,14 +873,6 @@
     display: none;
   }
 
-  .agent-panel__split.is-sidebar-collapsed {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(0, 1fr);
-  }
-
-  .agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar {
-    display: flex;
-  }
 
   .agent-panel__sidebar {
     gap: 0;
@@ -914,7 +907,7 @@
     transition: transform 120ms ease-in-out;
   }
 
-  .agent-panel__sidebar.is-open .agent-panel__sidebar-toggle::after {
+  .agent-panel__sidebar.is-mobile-sidebar-open .agent-panel__sidebar-toggle::after {
     transform: rotate(225deg);
   }
 
@@ -962,7 +955,7 @@
     grid-template-columns: 1fr;
     flex-direction: column;
   }
-  .agent-panel__sidebar.is-open .agent-panel__sidebar-content {
+  .agent-panel__sidebar.is-mobile-sidebar-open .agent-panel__sidebar-content {
     display: flex;
   }
 }

--- a/frontend/styles/components/_agent-panel.scss
+++ b/frontend/styles/components/_agent-panel.scss
@@ -38,6 +38,15 @@
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
 }
 
+.agent-panel.is-maximized {
+  top: var(--spacing-md);
+  right: var(--spacing-md);
+  bottom: var(--spacing-md);
+  left: var(--spacing-md);
+  width: auto;
+  max-height: none;
+}
+
 .agent-panel__split,
 .agent-panel__body,
 .agent-panel__empty {
@@ -64,15 +73,23 @@
   }
 }
 
+.agent-panel__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 .agent-panel__body,
 .agent-panel__empty {
   min-width: 0;
-  overflow: auto;
+  min-height: 0;
+  overflow: hidden;
   padding: var(--spacing-md);
 }
 
 .agent-panel__body {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: var(--spacing-md);
 }
@@ -106,6 +123,8 @@
 }
 
 .agent-panel__composer {
+  flex: 0 0 auto;
+  margin-top: auto;
   padding: var(--spacing-sm);
   border: 1px solid var(--line-color);
   border-radius: 8px;
@@ -138,7 +157,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--spacing-xs);
-  align-items: stretch;
+  align-items: end;
 }
 
 .agent-panel__prompt {
@@ -149,33 +168,21 @@
   color: var(--text-primary);
   padding: var(--spacing-sm);
   font: inherit;
-}
-
-.agent-panel__prompt {
-  min-height: 76px;
+  min-height: 42px;
   max-height: 180px;
   resize: vertical;
+  overflow-y: auto;
+  field-sizing: content;
 }
 
 .agent-panel__run-button {
-  min-width: 120px;
-  align-self: stretch;
-}
-
-.agent-panel__footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-xs);
-}
-
-.agent-panel__footer {
-  justify-content: space-between;
+  min-width: 88px;
+  height: 42px;
 }
 
 .agent-panel__log,
 .agent-panel__error {
   margin: 0;
-  max-height: 220px;
   overflow: auto;
   border: 1px solid var(--line-color);
   border-radius: 6px;
@@ -187,7 +194,13 @@
 }
 
 
+.agent-panel__log {
+  flex: 1;
+  min-height: 0;
+}
+
 .agent-panel__error {
+  max-height: 220px;
   color: var(--state-danger);
   border-color: var(--state-danger);
   background: var(--state-danger-outline);
@@ -198,9 +211,41 @@
 .agent-panel__split {
   display: grid;
   grid-template-columns: minmax(220px, 280px) 1fr;
+  grid-template-rows: minmax(0, 1fr);
   overflow: hidden;
   min-height: 0;
   flex: 1;
+}
+
+.agent-panel__split.is-sidebar-collapsed {
+  grid-template-columns: 44px 1fr;
+}
+
+.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar {
+  align-items: center;
+  padding: var(--spacing-sm) 0;
+}
+
+.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar-content {
+  display: none;
+}
+
+
+.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar-header {
+  justify-content: center;
+  padding: 0;
+}
+
+.agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar-header h3 {
+  display: none;
+}
+
+.agent-panel__split.is-sidebar-collapsed .agent-panel__new-chat {
+  padding-inline: var(--spacing-xs);
+}
+
+.agent-panel__split.is-sidebar-collapsed .agent-panel__new-chat span:not(.material-symbols-outlined) {
+  display: none;
 }
 
 .agent-panel__body,
@@ -212,9 +257,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
-  padding: var(--spacing-sm) var(--spacing-md);
+  padding: var(--spacing-sm) 0;
   border-right: 1px solid var(--line-color);
-  overflow: auto;
+  overflow: hidden;
   min-height: 0;
 }
 
@@ -222,13 +267,43 @@
   display: none;
 }
 
+.agent-panel__sidebar-collapse {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  margin-top: auto;
+  margin-left: 6px;
+}
+
+.agent-panel__new-chat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  height: 28px;
+  padding: 0 var(--spacing-sm);
+  border: 1px solid var(--line-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+}
+
+.agent-panel__new-chat:hover {
+  border-color: var(--text-secondary);
+  background: var(--bg-elevated);
+}
+
 .agent-panel__sidebar-content {
   display: flex;
+  padding: 0 var(--spacing-md);
   width: 100%;
   min-width: 0;
   max-width: 100%;
   flex-direction: column;
   gap: var(--spacing-xs);
+  flex: 1;
+  overflow: auto;
 }
 
 .agent-panel__sidebar-header {
@@ -236,6 +311,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-xs);
+  padding: 0 var(--spacing-md);
 
   h3 {
     margin: 0;
@@ -413,11 +489,17 @@
   }
 }
 
+.agent-panel__conversation {
+  flex: 1;
+  min-height: 0;
+}
+
 .agent-panel__chat {
   display: flex;
+  flex: 1;
+  min-height: 0;
   flex-direction: column;
   gap: var(--spacing-md);
-  max-height: 420px;
   overflow: auto;
   padding: var(--spacing-sm);
   border: 1px solid var(--line-color);
@@ -786,6 +868,19 @@
     grid-template-rows: auto minmax(0, 1fr);
   }
 
+  .agent-panel__sidebar-collapse {
+    display: none;
+  }
+
+  .agent-panel__split.is-sidebar-collapsed {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .agent-panel__split.is-sidebar-collapsed .agent-panel__sidebar {
+    display: flex;
+  }
+
   .agent-panel__sidebar {
     gap: 0;
     padding: 0;
@@ -839,7 +934,7 @@
     display: none;
   }
 
-  .agent-panel__sidebar-header .primary-btn {
+  .agent-panel__sidebar-header .agent-panel__new-chat {
     width: 100%;
   }
 


### PR DESCRIPTION
- Header
  - Minimize button
  - Maximize/restore button
- Sidebar collapse/expand
- New chat
  - Icon and text when open
  - Icon only when collapsed
- Cleanup
  - Removed footer and dead helpers/state
- Layout
  - Composer pinned bottom
  - Chat fills remaining height
  - Long chats scroll instead of hiding composer
  - Details pane fills available height
- Composer
  - Compact empty height
  - CSS autosize via field-sizing
  - Max height and internal scroll
  - Fixed-height Send button
- Reload workspace data after successful edit

<img width="1916" height="994" alt="image" src="https://github.com/user-attachments/assets/6e08f6a2-7020-47ba-a909-a46c83d49fdf" />

<img width="1919" height="993" alt="image" src="https://github.com/user-attachments/assets/9ab23a4c-043a-4522-bcff-f8a3bdcc83c0" />

