### PR TITLE
Ai agent improvements

### DIFF
--- a/backend/src/Agent/Git.hs
+++ b/backend/src/Agent/Git.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Agent.Git (
+    AgentApplyView (..),
     AgentGitState (..),
     AgentSessionView (..),
     AgentUsage (..),
@@ -72,6 +73,13 @@ data AgentSessionView = AgentSessionView
     { session :: AgentSession
     , gitState :: AgentGitState
     , turns :: [AgentTurn]
+    }
+    deriving (Show, Eq, Generic, ToJSON)
+
+data AgentApplyView = AgentApplyView
+    { sessionView :: AgentSessionView
+    , invalidatedProjectIds :: [Int]
+    , invalidatedStepIds :: [Int]
     }
     deriving (Show, Eq, Generic, ToJSON)
 
@@ -256,7 +264,7 @@ prepareApplyCandidate sid = do
             saveSessionUpdate session_{status = "prepare_conflict", preparedApply = Nothing, lastError = Just conflictSummary}
             loadAgentSessionView sid
 
-confirmApplyCandidate :: Text -> Text -> Text -> ExceptT String IO AgentSessionView
+confirmApplyCandidate :: Text -> Text -> Text -> ExceptT String IO AgentApplyView
 confirmApplyCandidate sid requestedTarget requestedCandidate = do
     session_ <- requireEditableSession sid
     candidate <- case preparedApply session_ of
@@ -285,7 +293,9 @@ confirmApplyCandidate sid requestedTarget requestedCandidate = do
             _ <- runGitChecked (worktreePath session_) ["clean", "-fd"]
             liftIO $ removeWorktreeIfExists repoPath (candidateWorktree candidate)
             changedPaths <- T.lines <$> runGitChecked repoPath ["diff", "--name-only", T.unpack (targetHead candidate) ++ ".." ++ candidateSha]
-            liftIO $ void $ forkIO $ broadcastAppliedStatuses (candidateHead candidate) changedPaths
+            let projectIds = nub (mapMaybe appliedProjectId changedPaths)
+                stepIds = nub (mapMaybe appliedStepId changedPaths)
+            liftIO $ void $ forkIO $ broadcastAppliedStatuses (candidateHead candidate) projectIds stepIds
             appendLifecycleTurn
                 sid
                 "Apply proposed changeset"
@@ -298,7 +308,8 @@ confirmApplyCandidate sid requestedTarget requestedCandidate = do
                     , preparedApply = Nothing
                     , lastError = Nothing
                     }
-            loadAgentSessionView sid
+            view_ <- loadAgentSessionView sid
+            return AgentApplyView{sessionView = view_, invalidatedProjectIds = projectIds, invalidatedStepIds = stepIds}
         (ExitFailure code, stdout, stderr) -> throwError $ "push_rejected: git push failed with exit code " ++ show code ++ formatGitOutput stdout stderr
 
 {- | Discard the proposed changeset but keep the chat usable: instead of
@@ -471,10 +482,10 @@ applied agent changeset, so open status streams pick up the new commit
 resolution takes the shared repo lock, which the apply handler still holds
 exclusively until it returns.
 -}
-broadcastAppliedStatuses :: Text -> [Text] -> IO ()
-broadcastAppliedStatuses commit paths = do
-    mapM_ (\pid -> broadcastProjectStatus pid commit Nothing) (nub (mapMaybe appliedProjectId paths))
-    mapM_ (\sid -> broadcastStatusForStepProjects sid commit Nothing) (nub (mapMaybe appliedStepId paths))
+broadcastAppliedStatuses :: Text -> [Int] -> [Int] -> IO ()
+broadcastAppliedStatuses commit projectIds stepIds = do
+    mapM_ (\pid -> broadcastProjectStatus pid commit Nothing) projectIds
+    mapM_ (\sid -> broadcastStatusForStepProjects sid commit Nothing) stepIds
 
 sessionHasActiveRunner :: AgentSession -> Bool
 sessionHasActiveRunner session_ =

--- a/backend/src/Agent/Git.hs
+++ b/backend/src/Agent/Git.hs
@@ -312,10 +312,6 @@ confirmApplyCandidate sid requestedTarget requestedCandidate = do
             return AgentApplyView{sessionView = view_, invalidatedProjectIds = projectIds, invalidatedStepIds = stepIds}
         (ExitFailure code, stdout, stderr) -> throwError $ "push_rejected: git push failed with exit code " ++ show code ++ formatGitOutput stdout stderr
 
-{- | Discard the proposed changeset but keep the chat usable: instead of
-deleting the agent branch and worktree, reset them to the current target
-head so the conversation can continue from a clean slate.
--}
 discardAgentSession :: Text -> ExceptT String IO AgentSessionView
 discardAgentSession sid = do
     session_ <- requireEditableSession sid
@@ -476,12 +472,6 @@ decimalId text_ =
         Right (n, rest) | T.null rest -> Just n
         _ -> Nothing
 
-{- | Broadcast fresh step statuses for the projects and steps touched by an
-applied agent changeset, so open status streams pick up the new commit
-(typically flipping run states to not-started). Run this forked: status
-resolution takes the shared repo lock, which the apply handler still holds
-exclusively until it returns.
--}
 broadcastAppliedStatuses :: Text -> [Int] -> [Int] -> IO ()
 broadcastAppliedStatuses commit projectIds stepIds = do
     mapM_ (\pid -> broadcastProjectStatus pid commit Nothing) projectIds

--- a/backend/src/Agent/Git.hs
+++ b/backend/src/Agent/Git.hs
@@ -301,23 +301,29 @@ confirmApplyCandidate sid requestedTarget requestedCandidate = do
             loadAgentSessionView sid
         (ExitFailure code, stdout, stderr) -> throwError $ "push_rejected: git push failed with exit code " ++ show code ++ formatGitOutput stdout stderr
 
+{- | Discard the proposed changeset but keep the chat usable: instead of
+deleting the agent branch and worktree, reset them to the current target
+head so the conversation can continue from a clean slate.
+-}
 discardAgentSession :: Text -> ExceptT String IO AgentSessionView
 discardAgentSession sid = do
-    session_ <- loadSessionOrThrow sid
+    session_ <- requireEditableSession sid
     when (sessionHasActiveRunner session_) $ throwError "runner_active"
     changesetDiff <- branchDiff <$> collectGitState session_
     repoPath <- liftIO userRepoPath
-    liftIO $ removeWorktreeIfExists repoPath (worktreePath session_)
+    latest <- stripOutput <$> runGitChecked repoPath ["rev-parse", T.unpack (targetBranch session_)]
+    _ <- runGitChecked (worktreePath session_) ["clean", "-fd"]
+    _ <- runGitChecked (worktreePath session_) ["reset", "--hard", T.unpack latest]
+    _ <- runGitChecked (worktreePath session_) ["clean", "-fd"]
     case preparedApply session_ of
         Nothing -> return ()
         Just candidate -> liftIO $ removeWorktreeIfExists repoPath (candidateWorktree candidate)
-    _ <- liftIO $ runGitIn repoPath ["branch", "-D", T.unpack (agentBranch session_)]
     appendLifecycleTurn
         sid
         "Discard proposed changeset"
-        ("Discarded this draft. No changes were applied to `" <> targetBranch session_ <> "`.")
+        ("Discarded this draft. No changes were applied to `" <> targetBranch session_ <> "`. You can continue from a clean state in this chat.")
         changesetDiff
-    saveSessionUpdate session_{status = "discarded", activeTurnId = Nothing, preparedApply = Nothing, lastError = Nothing}
+    saveSessionUpdate session_{status = "open", baseCommit = latest, activeTurnId = Nothing, preparedApply = Nothing, lastError = Nothing}
     loadAgentSessionView sid
 
 appendLifecycleTurn :: Text -> Text -> Text -> Text -> ExceptT String IO ()

--- a/backend/src/Agent/Git.hs
+++ b/backend/src/Agent/Git.hs
@@ -39,19 +39,22 @@ import Agent.Session (
     turnLogFilePath,
  )
 import Config (Config (..), UserRepoConfig (..), loadConfig, resolveConfigPath)
+import Control.Concurrent (forkIO)
 import Control.Exception (IOException, try)
-import Control.Monad (unless, when)
+import Control.Monad (unless, void, when)
 import Control.Monad.Except (ExceptT (..), runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (ToJSON)
-import Data.Char (isDigit)
 import Data.List (nub, sortOn)
+import Data.Maybe (isJust, mapMaybe)
 import Data.Ord (Down (..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import qualified Data.Text.Read as TR
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Generics (Generic)
+import Handlers.Statuses (broadcastProjectStatus, broadcastStatusForStepProjects)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, getModificationTime, removePathForcibly)
 import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory, (</>))
@@ -281,6 +284,8 @@ confirmApplyCandidate sid requestedTarget requestedCandidate = do
             _ <- runGitChecked (worktreePath session_) ["reset", "--hard", candidateSha]
             _ <- runGitChecked (worktreePath session_) ["clean", "-fd"]
             liftIO $ removeWorktreeIfExists repoPath (candidateWorktree candidate)
+            changedPaths <- T.lines <$> runGitChecked repoPath ["diff", "--name-only", T.unpack (targetHead candidate) ++ ".." ++ candidateSha]
+            liftIO $ void $ forkIO $ broadcastAppliedStatuses (candidateHead candidate) changedPaths
             appendLifecycleTurn
                 sid
                 "Apply proposed changeset"
@@ -430,20 +435,40 @@ hasStagedChanges worktree = ExceptT $ do
 
 isAgentOutputPath :: Text -> Bool
 isAgentOutputPath path =
+    isJust (appliedProjectId path) || isJust (appliedStepId path)
+
+appliedProjectId :: Text -> Maybe Int
+appliedProjectId path =
     case T.splitOn "/" path of
-        ["projects", file] -> isNumberedNix file
-        ["steps", file] -> isNumberedNix file
-        "srcFiles" : stepId : rest -> isDigits stepId && not (null rest)
-        _ -> False
+        ["projects", file] -> numberedNixId file
+        _ -> Nothing
 
-isNumberedNix :: Text -> Bool
-isNumberedNix file =
-    case T.stripSuffix ".nix" file of
-        Just stem -> isDigits stem
-        Nothing -> False
+appliedStepId :: Text -> Maybe Int
+appliedStepId path =
+    case T.splitOn "/" path of
+        ["steps", file] -> numberedNixId file
+        "srcFiles" : stepId : _ : _ -> decimalId stepId
+        _ -> Nothing
 
-isDigits :: Text -> Bool
-isDigits text_ = not (T.null text_) && T.all isDigit text_
+numberedNixId :: Text -> Maybe Int
+numberedNixId file = T.stripSuffix ".nix" file >>= decimalId
+
+decimalId :: Text -> Maybe Int
+decimalId text_ =
+    case TR.decimal text_ of
+        Right (n, rest) | T.null rest -> Just n
+        _ -> Nothing
+
+{- | Broadcast fresh step statuses for the projects and steps touched by an
+applied agent changeset, so open status streams pick up the new commit
+(typically flipping run states to not-started). Run this forked: status
+resolution takes the shared repo lock, which the apply handler still holds
+exclusively until it returns.
+-}
+broadcastAppliedStatuses :: Text -> [Text] -> IO ()
+broadcastAppliedStatuses commit paths = do
+    mapM_ (\pid -> broadcastProjectStatus pid commit Nothing) (nub (mapMaybe appliedProjectId paths))
+    mapM_ (\sid -> broadcastStatusForStepProjects sid commit Nothing) (nub (mapMaybe appliedStepId paths))
 
 sessionHasActiveRunner :: AgentSession -> Bool
 sessionHasActiveRunner session_ =

--- a/backend/src/Agent/Git.hs
+++ b/backend/src/Agent/Git.hs
@@ -13,6 +13,7 @@ module Agent.Git (
     renameAgentSession,
     loadAgentSessionView,
     commitAgentTurnOutputs,
+    refreshSessionBase,
     prepareApplyCandidate,
     confirmApplyCandidate,
     discardAgentSession,
@@ -40,7 +41,7 @@ import Agent.Session (
 import Config (Config (..), UserRepoConfig (..), loadConfig, resolveConfigPath)
 import Control.Exception (IOException, try)
 import Control.Monad (unless, when)
-import Control.Monad.Except (ExceptT (..), throwError)
+import Control.Monad.Except (ExceptT (..), runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (ToJSON)
 import Data.Char (isDigit)
@@ -154,6 +155,59 @@ commitAgentTurnOutputs session_ turn = do
                     _ <- runGitChecked (worktreePath session_) ["commit", "-m", "Agent turn " ++ T.unpack (turnId turn)]
                     head_ <- stripOutput <$> runGitChecked (worktreePath session_) ["rev-parse", "HEAD"]
                     return (Just head_, skippedPaths)
+
+refreshSessionBase :: AgentSession -> ExceptT String IO (AgentSession, [Text])
+refreshSessionBase session_ = do
+    fetchResult <- liftIO $ runExceptT fetchRepoStrict
+    let fetchNotes = case fetchResult of
+            Left err -> ["Warning: could not fetch latest repo state: " <> T.pack err]
+            Right () -> []
+    repoPath <- liftIO userRepoPath
+    latest <- stripOutput <$> runGitChecked repoPath ["rev-parse", T.unpack (targetBranch session_)]
+    worktreeExists <- liftIO $ doesDirectoryExist (worktreePath session_)
+    if latest == baseCommit session_ || not worktreeExists
+        then return (session_, fetchNotes)
+        else do
+            (updated, syncNote) <- syncWorktreeToTarget session_ latest
+            return (updated, fetchNotes ++ [syncNote])
+
+syncWorktreeToTarget :: AgentSession -> Text -> ExceptT String IO (AgentSession, Text)
+syncWorktreeToTarget session_ latest = do
+    head_ <- stripOutput <$> runGitChecked (worktreePath session_) ["rev-parse", "HEAD"]
+    if head_ == baseCommit session_
+        then do
+            -- No agent commits yet: stray uncommitted files are disposable
+            -- (same policy as confirmApplyCandidate), so jump straight to latest.
+            _ <- runGitChecked (worktreePath session_) ["clean", "-fd"]
+            _ <- runGitChecked (worktreePath session_) ["reset", "--hard", T.unpack latest]
+            advanceBase $ "Updated session to latest `" <> targetBranch session_ <> "` state (" <> shortCommit latest <> ")"
+        else do
+            mergeResult <-
+                liftIO $
+                    runGitIn
+                        (worktreePath session_)
+                        ["merge", "-m", "Merge latest " ++ T.unpack (targetBranch session_) ++ " into agent session", T.unpack latest]
+            case mergeResult of
+                (ExitSuccess, _, _) ->
+                    advanceBase $ "Merged latest `" <> targetBranch session_ <> "` state (" <> shortCommit latest <> ") into session"
+                (ExitFailure _, mergeOut, mergeErr) -> do
+                    _ <- liftIO $ runGitIn (worktreePath session_) ["merge", "--abort"]
+                    return
+                        ( session_
+                        , "Warning: could not merge latest `"
+                            <> targetBranch session_
+                            <> "` ("
+                            <> shortCommit latest
+                            <> ") into session; continuing from "
+                            <> shortCommit (baseCommit session_)
+                            <> "."
+                            <> T.pack (formatGitOutput mergeOut mergeErr)
+                        )
+  where
+    advanceBase note = do
+        let refreshed = session_{baseCommit = latest}
+        saveSessionUpdate refreshed
+        return (refreshed, note)
 
 prepareApplyCandidate :: Text -> ExceptT String IO AgentSessionView
 prepareApplyCandidate sid = do

--- a/backend/src/Agent/Git.hs
+++ b/backend/src/Agent/Git.hs
@@ -43,7 +43,7 @@ import Config (Config (..), UserRepoConfig (..), loadConfig, resolveConfigPath)
 import Control.Concurrent (forkIO)
 import Control.Exception (IOException, try)
 import Control.Monad (unless, void, when)
-import Control.Monad.Except (ExceptT (..), runExceptT, throwError)
+import Control.Monad.Except (ExceptT (..), catchError, throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (ToJSON)
 import Data.List (nub, sortOn)
@@ -169,10 +169,10 @@ commitAgentTurnOutputs session_ turn = do
 
 refreshSessionBase :: AgentSession -> ExceptT String IO (AgentSession, [Text])
 refreshSessionBase session_ = do
-    fetchResult <- liftIO $ runExceptT fetchRepoStrict
-    let fetchNotes = case fetchResult of
-            Left err -> ["Warning: could not fetch latest repo state: " <> T.pack err]
-            Right () -> []
+    fetchNotes <-
+        (fetchRepoStrict >> pure [])
+            `catchError` \err ->
+                pure ["Warning: could not fetch latest repo state: " <> T.pack err]
     repoPath <- liftIO userRepoPath
     latest <- stripOutput <$> runGitChecked repoPath ["rev-parse", T.unpack (targetBranch session_)]
     worktreeExists <- liftIO $ doesDirectoryExist (worktreePath session_)

--- a/backend/src/Agent/Runner.hs
+++ b/backend/src/Agent/Runner.hs
@@ -7,7 +7,7 @@ module Agent.Runner (
     turnLogStreamHandler,
 ) where
 
-import Agent.Git (commitAgentTurnOutputs)
+import Agent.Git (commitAgentTurnOutputs, refreshSessionBase)
 import Agent.Sandbox (nixDaemonBindArgs)
 import Agent.Session (
     AgentSession (..),
@@ -59,6 +59,9 @@ startAgentTurn sid prompt = do
     when (status session_ == "archived") $ Except.throwError "session_archived"
     when (status session_ == "running" || activeTurnId session_ /= Nothing) $ Except.throwError "runner_active"
     cfg <- liftIO $ resolveConfigPath >>= loadConfig
+    -- Sync the session worktree with the latest target branch state so the
+    -- agent sees changes made while the thread was inactive.
+    (freshSession, syncNotes) <- refreshSessionBase session_
     tid <- liftIO newTurnId
     logPath <- liftIO $ turnLogFilePath sid tid
     now <- liftIO getCurrentTime
@@ -77,16 +80,17 @@ startAgentTurn sid prompt = do
     liftIO $ do
         createDirectoryIfMissing True (takeDirectory logPath)
         TIO.writeFile logPath ""
+        mapM_ (appendLogLine (configAgent cfg) logPath "system") syncNotes
         existingTurns <- listTurns sid
         let isFirstTurn = null existingTurns
-            shouldAutoName = isFirstTurn && maybe True (T.null . T.strip) (sessionName session_)
+            shouldAutoName = isFirstTurn && maybe True (T.null . T.strip) (sessionName freshSession)
             namedSession =
                 if shouldAutoName
                     then case normalizeSessionName prompt of
-                        Just name -> session_{sessionName = Just name}
-                        Nothing -> session_
+                        Just name -> freshSession{sessionName = Just name}
+                        Nothing -> freshSession
                     else
-                        session_
+                        freshSession
         saveTurn turn
         touched <- touchSession namedSession{status = "running", activeTurnId = Just tid, preparedApply = Nothing, lastError = Nothing}
         saveSession touched

--- a/backend/src/Agent/Runner.hs
+++ b/backend/src/Agent/Runner.hs
@@ -59,8 +59,6 @@ startAgentTurn sid prompt = do
     when (status session_ == "archived") $ Except.throwError "session_archived"
     when (status session_ == "running" || activeTurnId session_ /= Nothing) $ Except.throwError "runner_active"
     cfg <- liftIO $ resolveConfigPath >>= loadConfig
-    -- Sync the session worktree with the latest target branch state so the
-    -- agent sees changes made while the thread was inactive.
     (freshSession, syncNotes) <- refreshSessionBase session_
     tid <- liftIO newTurnId
     logPath <- liftIO $ turnLogFilePath sid tid

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -4,7 +4,7 @@
 -- | The backend HTTP API, served by @Main@ and documented by @Docs.OpenApi@.
 module Api (API) where
 
-import Agent.Git (AgentSessionView, AgentUsage)
+import Agent.Git (AgentApplyView, AgentSessionView, AgentUsage)
 import Agent.Session (AgentTurn)
 import ApiTypes (DynamicJson)
 import qualified Data.ByteString as BS
@@ -145,7 +145,7 @@ type ConfirmApply =
         :> "confirm-apply"
         :> Description "Applies a prepared agent session's changes to the target branch."
         :> ReqBody '[JSON] ConfirmApplyRequest
-        :> Post '[JSON] AgentSessionView
+        :> Post '[JSON] AgentApplyView
 
 type DiscardSession =
     "agent"

--- a/backend/src/Docs/OpenApi.hs
+++ b/backend/src/Docs/OpenApi.hs
@@ -15,7 +15,7 @@ real Servant combinators that carry no schema by default.
 -}
 module Docs.OpenApi (pointyOpenApi) where
 
-import Agent.Git (AgentGitState, AgentSessionView, AgentUsage)
+import Agent.Git (AgentApplyView, AgentGitState, AgentSessionView, AgentUsage)
 import Agent.Session (AgentSession, AgentTurn, PreparedApply)
 import Api (API)
 import ApiTypes (DynamicJson)
@@ -135,6 +135,7 @@ instance ToSchema AgentSession
 instance ToSchema AgentTurn
 instance ToSchema AgentGitState
 instance ToSchema AgentSessionView
+instance ToSchema AgentApplyView
 instance ToSchema AgentUsage
 
 -- | The complete OpenAPI specification.

--- a/backend/src/Handlers/Agent.hs
+++ b/backend/src/Handlers/Agent.hs
@@ -22,6 +22,7 @@ module Handlers.Agent (
 ) where
 
 import Agent.Git (
+    AgentApplyView,
     AgentSessionView,
     AgentUsage,
     archiveAgentSession,
@@ -111,7 +112,7 @@ prepareApplyHandler :: SessionRequest -> Handler AgentSessionView
 prepareApplyHandler req =
     runLockedAction $ prepareApplyCandidate (sessionRequestSessionId req)
 
-confirmApplyHandler :: ConfirmApplyRequest -> Handler AgentSessionView
+confirmApplyHandler :: ConfirmApplyRequest -> Handler AgentApplyView
 confirmApplyHandler req =
     runLockedAction $ confirmApplyCandidate (confirmSessionId req) (confirmTargetHead req) (confirmCandidateHead req)
 

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -278,13 +278,7 @@ replayStepStatusBuffer =
                     applyOne ( stepId, ( commit, status ) ) =
                         Flow.over
                             (projects << records << success << each << tables << values << records << success << by .id (Just stepId) << runState)
-                            (\rs ->
-                                let
-                                    current =
-                                        ApiData.withDefault { commit = commit, status = NotAsked, directoryView = { children = NotAsked, expanded = False, extras = NotAsked } } rs
-                                in
-                                Success { current | commit = commit, status = Success status }
-                            )
+                            (applyStatusSnapshot commit status)
                 in
                 get stepStatusBuffer model
                     |> Dict.toList
@@ -292,6 +286,25 @@ replayStepStatusBuffer =
                     |> Flow.batchM
                     |> Flow.seq (Flow.setAll stepStatusBuffer Dict.empty)
             )
+
+
+applyStatusSnapshot : String -> Status -> ApiData Model.StepRunState -> ApiData Model.StepRunState
+applyStatusSnapshot snapshotCommit newStatus rs =
+    let
+        collapsedDirectoryView =
+            { children = NotAsked, expanded = False, extras = NotAsked }
+
+        current =
+            ApiData.withDefault { commit = snapshotCommit, status = NotAsked, directoryView = collapsedDirectoryView } rs
+
+        directoryView_ =
+            if current.commit == snapshotCommit then
+                current.directoryView
+
+            else
+                collapsedDirectoryView
+    in
+    Success { current | commit = snapshotCommit, status = Success newStatus, directoryView = directoryView_ }
 
 
 loadUserRepoInfo : Flow Model ()
@@ -2820,22 +2833,12 @@ updateStepStatus snapshotCommit stepId newStatus =
     let
         stepRunState =
             projects << records << success << each << tables << values << records << success << by .id (Just stepId) << runState
-
-        defaultRunState =
-            { commit = snapshotCommit, status = NotAsked, directoryView = { children = NotAsked, expanded = False, extras = NotAsked } }
     in
     Flow.get
         |> Flow.andThen
             (\model ->
                 if has stepRunState model then
-                    Flow.over stepRunState
-                        (\rs ->
-                            let
-                                current =
-                                    ApiData.withDefault defaultRunState rs
-                            in
-                            Success { current | commit = snapshotCommit, status = Success newStatus }
-                        )
+                    Flow.over stepRunState (applyStatusSnapshot snapshotCommit newStatus)
                         |> Flow.seq (Flow.over stepStatusBuffer (Dict.remove stepId))
 
                 else

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -2574,8 +2574,9 @@ applyAgentChanges =
                                                     |> Flow.andThen
                                                         (\confirmResult ->
                                                             case confirmResult of
-                                                                Ok appliedView ->
-                                                                    handleAgentSessionResult False (Ok appliedView)
+                                                                Ok applyView ->
+                                                                    handleAgentSessionResult False (Ok applyView.sessionView)
+                                                                        |> Flow.seq (markInvalidatedStatusesLoading applyView)
                                                                         |> Flow.seq reloadWorkspaceData
                                                                         |> Flow.seq loadAgentSessions
                                                                         |> Flow.seq (clearChangesetOperation view.session.sessionId)
@@ -2597,6 +2598,18 @@ applyAgentChanges =
                             )
                     )
         )
+
+
+markInvalidatedStatusesLoading : Model.AgentApplyView -> Flow Model ()
+markInvalidatedStatusesLoading applyView =
+    let
+        wipeProject projectId =
+            Flow.setAll (projects << records << success << by .id (Just projectId) << projectStepRecords << runState) (ApiData.loading Nothing)
+
+        wipeStep stepId =
+            Flow.setAll (projects << records << success << each << tables << values << records << success << by .id (Just stepId) << runState) (ApiData.loading Nothing)
+    in
+    Flow.batchM (List.map wipeProject applyView.invalidatedProjectIds ++ List.map wipeStep applyView.invalidatedStepIds)
 
 
 discardAgentSession : Flow Model ()

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -1979,10 +1979,10 @@ defaultChangesetDescription : Model.ChatChangesetState -> String
 defaultChangesetDescription state =
     case state of
         Model.ChatChangesetProposed ->
-            "Review this changeset, then apply it to the target branch or discard the chat."
+            "Review this changeset, then apply it to the target branch or discard it."
 
         Model.ChatChangesetNeedsReview _ ->
-            "This changeset could not be prepared cleanly. Resolve the issue by continuing the conversation, or discard the chat."
+            "This changeset could not be prepared cleanly. Resolve the issue by continuing the conversation, or discard the changeset."
 
         Model.ChatChangesetApplied ->
             "This changeset was applied. You can continue the conversation from the applied state."

--- a/frontend/src/Api/Agent.elm
+++ b/frontend/src/Api/Agent.elm
@@ -73,15 +73,20 @@ prepareApply sessionId =
     postSessionView "/prepare-apply" (sessionIdBody sessionId)
 
 
-confirmApply : String -> String -> String -> Flow s (Result Http.Error Model.AgentSessionView)
+confirmApply : String -> String -> String -> Flow s (Result Http.Error Model.AgentApplyView)
 confirmApply sessionId targetHead candidateHead =
-    postSessionView "/confirm-apply"
-        (Encode.object
-            [ ( "sessionId", Encode.string sessionId )
-            , ( "targetHead", Encode.string targetHead )
-            , ( "candidateHead", Encode.string candidateHead )
-            ]
-        )
+    Flow.lift <|
+        Http.post
+            { url = baseUrl ++ "/confirm-apply"
+            , body =
+                Http.jsonBody <|
+                    Encode.object
+                        [ ( "sessionId", Encode.string sessionId )
+                        , ( "targetHead", Encode.string targetHead )
+                        , ( "candidateHead", Encode.string candidateHead )
+                        ]
+            , expect = Http.expectJson identity applyViewDecoder
+            }
 
 
 discardSession : String -> Flow s (Result Http.Error Model.AgentSessionView)
@@ -120,6 +125,14 @@ sessionViewDecoder =
         |> required "session" sessionDecoder
         |> required "gitState" gitStateDecoder
         |> required "turns" (Decode.list turnDecoder)
+
+
+applyViewDecoder : Decoder Model.AgentApplyView
+applyViewDecoder =
+    Decode.succeed Model.AgentApplyView
+        |> required "sessionView" sessionViewDecoder
+        |> required "invalidatedProjectIds" (Decode.list Decode.int)
+        |> required "invalidatedStepIds" (Decode.list Decode.int)
 
 
 sessionDecoder : Decoder Model.AgentSession

--- a/frontend/src/Components/AgentPanel.elm
+++ b/frontend/src/Components/AgentPanel.elm
@@ -29,17 +29,19 @@ view model =
             [ View.Icons.iconCustom False "smart_toy" []
             , Html.span [] [ Html.text "Agent" ]
             ]
-        , if agent.isPanelOpen then
-            viewPanel agent
-
-          else
-            Html.text ""
+        , viewPanel agent
         ]
 
 
 viewPanel : Model.AgentState -> Html (Flow Model ())
 viewPanel agent =
-    Html.div [ classList [ ( "agent-panel", True ), ( "is-maximized", agent.isMaximized ) ] ]
+    Html.div
+        [ classList
+            [ ( "agent-panel", True )
+            , ( "is-maximized", agent.isMaximized )
+            , ( "is-minimized", not agent.isPanelOpen )
+            ]
+        ]
         [ Html.div [ class "agent-panel__header" ]
             [ Html.div []
                 [ Html.h2 [] [ Html.text "AI agent" ]

--- a/frontend/src/Components/AgentPanel.elm
+++ b/frontend/src/Components/AgentPanel.elm
@@ -509,11 +509,7 @@ viewPrompt runnerActive =
                 "Send"
     in
     Html.div [ class "agent-panel__section agent-panel__composer" ]
-        [ Html.div [ class "agent-panel__composer-header" ]
-            [ Html.h3 [] [ Html.text "Message" ]
-            , Html.span [ class "agent-panel__shortcut" ] [ Html.text "Ctrl/⌘+Enter" ]
-            ]
-        , Html.div [ class "agent-panel__composer-row" ]
+        [ Html.div [ class "agent-panel__composer-row" ]
             [ Html.textarea
                 [ class "agent-panel__prompt"
                 , id "agent-prompt"
@@ -528,9 +524,11 @@ viewPrompt runnerActive =
                 [ class "primary-btn agent-panel__run-button"
                 , disabled runnerActive
                 , Events.onClick Actions.submitAgentPrompt
-                , title "Send message"
+                , title "Send message (Ctrl/⌘+Enter)"
                 ]
-                [ Html.text buttonText ]
+                [ Html.text buttonText
+                , Html.span [ class "agent-panel__run-hint" ] [ Html.text "Ctrl/⌘+Enter" ]
+                ]
             ]
         ]
 

--- a/frontend/src/Components/AgentPanel.elm
+++ b/frontend/src/Components/AgentPanel.elm
@@ -778,10 +778,10 @@ defaultChangesetDescription : Model.ChatChangesetState -> String
 defaultChangesetDescription state =
     case state of
         Model.ChatChangesetProposed ->
-            "Review this changeset, then apply it to the target branch or discard the chat."
+            "Review this changeset, then apply it to the target branch or discard it."
 
         Model.ChatChangesetNeedsReview _ ->
-            "This changeset could not be prepared cleanly. Resolve the issue by continuing the conversation, or discard the chat."
+            "This changeset could not be prepared cleanly. Resolve the issue by continuing the conversation, or discard the changeset."
 
         Model.ChatChangesetApplied ->
             "This changeset was applied. You can continue the conversation from the applied state."

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -190,6 +190,13 @@ type alias AgentSessionView =
     }
 
 
+type alias AgentApplyView =
+    { sessionView : AgentSessionView
+    , invalidatedProjectIds : List Int
+    , invalidatedStepIds : List Int
+    }
+
+
 type ChatTurnStatus
     = ChatPending
     | ChatDone

--- a/frontend/styles/components/_agent-panel.scss
+++ b/frontend/styles/components/_agent-panel.scss
@@ -38,6 +38,10 @@
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
 }
 
+.agent-panel.is-minimized {
+  display: none;
+}
+
 .agent-panel.is-maximized {
   top: var(--spacing-md);
   right: var(--spacing-md);

--- a/frontend/styles/components/_agent-panel.scss
+++ b/frontend/styles/components/_agent-panel.scss
@@ -62,7 +62,7 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--spacing-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
+  padding: var(--spacing-xs) var(--spacing-md);
   border-bottom: 1px solid var(--line-color);
   background: var(--bg-secondary);
 
@@ -88,14 +88,14 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  padding: var(--spacing-md);
+  padding: var(--spacing-sm);
 }
 
 .agent-panel__body {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
 }
 
 .agent-panel__empty {
@@ -129,32 +129,6 @@
 .agent-panel__composer {
   flex: 0 0 auto;
   margin-top: auto;
-  padding: var(--spacing-sm);
-  border: 1px solid var(--line-color);
-  border-radius: 8px;
-  background: var(--bg-secondary);
-}
-
-.agent-panel__composer-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--spacing-sm);
-
-  p {
-    margin-top: 2px;
-    font-size: var(--font-size-sm);
-  }
-}
-
-.agent-panel__shortcut {
-  flex: 0 0 auto;
-  border: 1px solid var(--line-color);
-  border-radius: 999px;
-  padding: 2px var(--spacing-xs);
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
-  white-space: nowrap;
 }
 
 .agent-panel__composer-row {
@@ -180,8 +154,19 @@
 }
 
 .agent-panel__run-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   min-width: 88px;
   height: 42px;
+}
+
+.agent-panel__run-hint {
+  font-size: 10px;
+  font-weight: 400;
+  opacity: 0.7;
+  line-height: 1.2;
 }
 
 .agent-panel__log,
@@ -393,7 +378,7 @@
 }
 
 .agent-panel__session-title-card {
-  padding: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
   border: 1px solid var(--line-color);
   border-radius: 8px;
   background: var(--bg-secondary);
@@ -504,7 +489,7 @@
   flex: 1;
   min-height: 0;
   flex-direction: column;
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
   overflow: auto;
   padding: var(--spacing-sm);
   border: 1px solid var(--line-color);
@@ -540,8 +525,8 @@
   min-width: 0;
   max-width: 100%;
   flex-direction: column;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-md);
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
   border: 1px solid var(--line-color);
   border-radius: 10px;
   background: var(--bg-secondary);


### PR DESCRIPTION
Closes #84, closes #85, closes #88 

 - sync agent session with latest state before turn — turns ran on a stale checkout; now each turn fast-forwards/merges the worktree to the target head, degrading gracefully on conflict                                                   
 - refresh status after agent apply — statuses and output browsers stayed stale until page reload; the backend now broadcasts fresh statuses for affected steps, and the frontend drops stale output views on the new-commit snapshot   
 - keep chat open on changeset discard — discard destroyed the session; now it resets the worktree to the target head, keeps the chat usable, and records a "Discarded" entry          
 - preserve chat prompt across panel minimize — minimizing unmounted the panel and lost typed text; it now stays mounted, hidden via CSS                       
 - instant status feedback after agent apply — closed the ~1–2s stale window: confirm-apply returns the invalidated project/step IDs, the frontend flips exactly those to loading (closing their output browsers) until the broadcast resolves them
 - tighten agent panel chat layout — reduced compounding container paddings, dropped the composer header/wrapper, moved the send hint into the button; the composer is now exactly input-height                                                                                                                                                      

<img width="1920" height="996" alt="image" src="https://github.com/user-attachments/assets/f441b17b-b272-4db7-98df-97feedc9fd4a" />
