### PR TITLE
Global step status stream with per-project refresh

### DIFF
--- a/backend/app/Main.hs
+++ b/backend/app/Main.hs
@@ -28,14 +28,14 @@ import Handlers.Agent (
     usageHandler,
  )
 import Handlers.Autocomplete (autocompleteHandler)
+import Handlers.ClusterStream (clusterStatusStreamHandler, startClusterPoller)
 import Handlers.CommitHash (getCommitHashHandler)
 import Handlers.Presets (getPresetsHandler)
 import Handlers.ProjectEntities (assignRecordHandler, batchAssignRecordsHandler, unassignRecordHandler)
 import Handlers.Projects (batchUpdateProjectsHandler, deleteProjectHandler, getProjectsHandler, patchProjectHandler, postProjectHandler)
 import Handlers.RunStep (restoreJobsFromSlurm, runStepHandler, stepLogHandler, stopStepHandler)
-import Handlers.ClusterStream (clusterStatusStreamHandler, startClusterPoller)
 import Handlers.SrcFiles (createSrcFileHandler, deleteSrcFileHandler, downloadSrcFilesHandler, getUserRepoInfoHandler, listSrcFilesHandler, saveSrcFileHandler, seekSrcFilesHandler)
-import Handlers.StatusStream (stepStatusStreamHandler)
+import Handlers.StatusStream (projectStatusHandler, stepStatusStreamHandler)
 import Handlers.Statuses (restoreRunningStatuses)
 import Handlers.StepConfig (getStepConfigHandler)
 import Handlers.Steps (noticesHandler, patchStepHandler, postStepHandler)
@@ -50,7 +50,6 @@ import Servant hiding (runHandler)
 import Servant.Multipart
 import System.IO (BufferMode (..), hSetBuffering, stdout)
 import UserRepo (ensureUserRepo, fetchRepo)
-
 
 server :: Server API
 server =
@@ -77,6 +76,7 @@ server =
         :<|> batchAssignRecordsHandler
         :<|> unassignRecordHandler
         :<|> stepStatusStreamHandler
+        :<|> projectStatusHandler
         :<|> getStepConfigHandler
         :<|> getPresetsHandler
         :<|> autocompleteHandler

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -44,6 +44,7 @@ library
     NixEvaluator
     NixUtils
     OutPaths
+    Sse
     UserRepo
 
   other-modules:

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -167,3 +167,20 @@ test-suite turn-stream
 
   hs-source-dirs:   test
   default-language: Haskell2010
+
+test-suite status-stream
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  main-is:          StatusStreamTest.hs
+  -- registerDelay (used by the stream heartbeat) requires -threaded.
+  ghc-options:      -threaded
+  build-depends:
+    , backend
+    , base
+    , bytestring
+    , containers
+    , servant
+    , stm
+
+  hs-source-dirs:   test
+  default-language: Haskell2010

--- a/backend/src/Agent/Runner.hs
+++ b/backend/src/Agent/Runner.hs
@@ -41,17 +41,16 @@ import qualified Control.Monad.Except as Except
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as TIO
 import Data.Time.Clock (getCurrentTime)
 import Servant (Handler, Header, Headers, addHeader, err404, errBody, throwError)
 import qualified Servant.Types.SourceT as S
+import Sse (sseComment, sseEvent)
 import System.Directory (copyFile, createDirectoryIfMissing, doesFileExist, getFileSize, getHomeDirectory)
 import System.Environment (getEnvironment)
 import System.Exit (ExitCode (..))
@@ -559,14 +558,3 @@ streamLoop turn offset signal = return $ S.Effect $ do
                         S.Yield
                             (sseEvent "heartbeat" (Aeson.encode (Aeson.object ["turnId" Aeson..= turnId turn])))
                             (S.Effect (streamLoop turn newOffset signal))
-
-sseEvent :: Text -> LBS.ByteString -> BS.ByteString
-sseEvent eventName payload =
-    TE.encodeUtf8 ("event: " <> eventName <> "\n")
-        <> "data: "
-        <> LBS.toStrict payload
-        <> "\n\n"
-
-sseComment :: Text -> BS.ByteString
-sseComment text_ =
-    TE.encodeUtf8 (": " <> text_ <> "\n\n")

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -305,10 +305,15 @@ type BatchUpdateProjects =
 
 type StepStatusStream =
     "step-status-stream"
-        :> Description "Streams snapshot and heartbeat SSE events for a project's steps. Emits status-error and closes when status evaluation fails."
+        :> Description "Streams snapshot and heartbeat SSE events for every project's steps."
+        :> StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
+
+type ProjectStatus =
+    "project-status"
+        :> Description "Re-evaluates a project's step statuses and broadcasts them on the step status stream."
         :> ReqProjectId
         :> QueryParam "commit" Text
-        :> StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
+        :> Post '[PlainText] NoContent
 
 type GetStepConfig =
     "step-config"
@@ -389,6 +394,7 @@ type API =
         :<|> BatchAssignRecords
         :<|> UnassignRecord
         :<|> StepStatusStream
+        :<|> ProjectStatus
         :<|> GetStepConfig
         :<|> GetPresets
         :<|> Autocomplete

--- a/backend/src/Api.hs
+++ b/backend/src/Api.hs
@@ -26,6 +26,12 @@ type ReqProjectId = QueryParam' '[Required, Strict] "project_id" Int
 
 type ReqEntityId = QueryParam' '[Required, Strict] "entity_id" Int
 
+{- | Standard SSE endpoint: unframed @text\/event-stream@ with the two
+headers that stop proxies from buffering or transforming events.
+-}
+type SseStream =
+    StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
+
 type GetCommitHash =
     "commit-hash"
         :> Description "Returns the commit hash the user repository is currently checked out at."
@@ -306,7 +312,7 @@ type BatchUpdateProjects =
 type StepStatusStream =
     "step-status-stream"
         :> Description "Streams snapshot and heartbeat SSE events for every project's steps."
-        :> StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
+        :> SseStream
 
 type ProjectStatus =
     "project-status"
@@ -359,7 +365,7 @@ type Upload =
 type ClusterStatusStream =
     "cluster-status-stream"
         :> Description "Streams the current SLURM cluster availability and subsequent status changes."
-        :> StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
+        :> SseStream
 
 type AgentTurnStream =
     "agent"
@@ -367,7 +373,7 @@ type AgentTurnStream =
         :> Capture "id" Text
         :> "stream"
         :> Description "Streams output of an agent turn as server-sent events."
-        :> StreamGet NoFraming EventStream (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (SourceT IO BS.ByteString))
+        :> SseStream
 
 -- | The full served API, in handler order (matches @Main.server@).
 type API =

--- a/backend/src/Bus.hs
+++ b/backend/src/Bus.hs
@@ -17,10 +17,27 @@ data ProjectSnapshot = ProjectSnapshot
 statusBus :: TChan ProjectSnapshot
 statusBus = unsafePerformIO newBroadcastTChanIO
 
+{- | Bounded history of the most recent snapshots.  @subscribe@ replays it
+onto each new channel so a client that connects (or the global status
+stream reconnecting) just after a broadcast does not lose it: broadcast
+channels hold no history of their own.
+-}
+{-# NOINLINE recentSnapshots #-}
+recentSnapshots :: TVar [ProjectSnapshot]
+recentSnapshots = unsafePerformIO $ newTVarIO []
+
+replayLimit :: Int
+replayLimit = 256
+
 broadcastSnapshot :: Int -> Text -> Map Int (Text, Maybe Text) -> IO ()
 broadcastSnapshot pid c stats = atomically $ do
     writeTChan statusBus (ProjectSnapshot pid c stats)
+    modifyTVar' recentSnapshots (take replayLimit . (ProjectSnapshot pid c stats :))
     updateRunningSteps stats
 
 subscribe :: IO (TChan ProjectSnapshot)
-subscribe = atomically $ dupTChan statusBus
+subscribe = atomically $ do
+    chan <- dupTChan statusBus
+    recent <- readTVar recentSnapshots
+    mapM_ (writeTChan chan) (reverse recent)
+    pure chan

--- a/backend/src/Handlers/ClusterStream.hs
+++ b/backend/src/Handlers/ClusterStream.hs
@@ -5,10 +5,10 @@
 
 module Handlers.ClusterStream (clusterStatusStreamHandler, startClusterPoller) where
 
-import ClusterBus (ClusterStatus (..), ClusterSnapshot (..), setClusterStatus, snapshotAndSubscribe)
+import ClusterBus (ClusterSnapshot (..), ClusterStatus (..), setClusterStatus, snapshotAndSubscribe)
 import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.STM (TChan)
 import Control.Exception (IOException, try)
-import Control.Concurrent.STM (TChan, TVar, atomically, orElse, readTChan, readTVar, registerDelay, retry)
 import Control.Monad (forever, void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (encode, object, (.=))
@@ -16,15 +16,16 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Set as Set
 import Data.Text (Text)
-import qualified Data.Text.Encoding as TE
-import System.Process (readProcessWithExitCode)
 import Servant (Handler, Header, Headers, addHeader)
 import qualified Servant.Types.SourceT as S
+import qualified Sse
 import System.Exit (ExitCode (..))
+import System.Process (readProcessWithExitCode)
 
--- | Query SLURM via sinfo to determine cluster availability.
--- Returns Unavailable if sinfo is not reachable, Available if all
--- partitions report "up", Degraded otherwise.
+{- | Query SLURM via sinfo to determine cluster availability.
+Returns Unavailable if sinfo is not reachable, Available if all
+partitions report "up", Degraded otherwise.
+-}
 checkClusterStatus :: IO ClusterStatus
 checkClusterStatus = do
     result <- try @IOException $ readProcessWithExitCode "sinfo" ["-h", "-o", "%a"] ""
@@ -36,22 +37,25 @@ checkClusterStatus = do
                 let states = filter (not . null) (lines stdout)
                  in if null states
                         then Unavailable
-                        else if all (== "up") states
-                            then Available
-                            else Degraded
--- | Synchronously check cluster status and store it, then fork a
--- background loop that re-checks every 30 seconds.
+                        else
+                            if all (== "up") states
+                                then Available
+                                else Degraded
+
+{- | Synchronously check cluster status and store it, then fork a
+background loop that re-checks every 30 seconds.
+-}
 startClusterPoller :: IO ()
 startClusterPoller = do
     status <- checkClusterStatus
     setClusterStatus status
     void $ forkIO $ forever $ do
-        threadDelay (30 * 1000000)
+        threadDelay Sse.heartbeatDelayMicros
         status' <- checkClusterStatus
         setClusterStatus status'
 
-clusterStatusStreamHandler
-    :: Handler
+clusterStatusStreamHandler ::
+    Handler
         ( Headers
             '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text]
             (S.SourceT IO BS.ByteString)
@@ -61,45 +65,24 @@ clusterStatusStreamHandler = do
     let source =
             S.fromStepT
                 ( S.Yield
-                    (sseEvent "cluster-status" (encodeSnapshot initialSnapshot))
+                    (Sse.sseEvent "cluster-status" (encodeSnapshot initialSnapshot))
                     (S.Effect (streamLoop busChan))
                 )
     pure $ addHeader "no-transform" $ addHeader "no" source
 
-
--- | Block on the snapshot broadcast channel, racing against a 30-second
--- heartbeat.  A new snapshot fires a @cluster-status@ SSE event; a timeout
--- fires an empty @heartbeat@.
 streamLoop :: TChan ClusterSnapshot -> IO (S.StepT IO BS.ByteString)
-streamLoop chan = return $ S.Effect $ do
-    delay <- registerDelay (30 * 1000000)
-    mSnapshot <- atomically $
-        (Just <$> readTChan chan) `orElse`
-        (readTVar delay >>= \b -> if b then pure Nothing else retry)
-    let event = case mSnapshot of
-            Just snapshot ->
-                sseEvent "cluster-status" (encodeSnapshot snapshot)
-            Nothing ->
-                sseEvent "heartbeat" (encode (object []))
-    return $ S.Yield event (S.Effect (streamLoop chan))
-
+streamLoop chan =
+    Sse.broadcastLoop (\snapshot -> ("cluster-status", encodeSnapshot snapshot)) chan
 
 encodeSnapshot :: ClusterSnapshot -> LBS.ByteString
 encodeSnapshot snapshot =
-    encode $ object
-        [ "status" .= statusText (clusterStatus snapshot)
-        , "runningStepIds" .= Set.toList (runningStepIds snapshot)
-        ]
+    encode $
+        object
+            [ "status" .= statusText (clusterStatus snapshot)
+            , "runningStepIds" .= Set.toList (runningStepIds snapshot)
+            ]
 
 statusText :: ClusterStatus -> Text
 statusText Available = "available"
 statusText Degraded = "degraded"
 statusText Unavailable = "unavailable"
-
-sseEvent :: Text -> LBS.ByteString -> BS.ByteString
-sseEvent eventName payload =
-    TE.encodeUtf8 ("event: " <> eventName <> "\n")
-        <> "data: "
-        <> LBS.toStrict payload
-        <> "\n\n"
-

--- a/backend/src/Handlers/ClusterStream.hs
+++ b/backend/src/Handlers/ClusterStream.hs
@@ -71,8 +71,7 @@ clusterStatusStreamHandler = do
     pure $ addHeader "no-transform" $ addHeader "no" source
 
 streamLoop :: TChan ClusterSnapshot -> IO (S.StepT IO BS.ByteString)
-streamLoop chan =
-    Sse.broadcastLoop (\snapshot -> ("cluster-status", encodeSnapshot snapshot)) chan
+streamLoop = Sse.broadcastLoop ((,) "cluster-status" . encodeSnapshot)
 
 encodeSnapshot :: ClusterSnapshot -> LBS.ByteString
 encodeSnapshot snapshot =

--- a/backend/src/Handlers/StatusStream.hs
+++ b/backend/src/Handlers/StatusStream.hs
@@ -8,7 +8,7 @@ module Handlers.StatusStream (EventStream, stepStatusStreamHandler, projectStatu
 import Bus (ProjectSnapshot, subscribe)
 import qualified Bus
 import Control.Concurrent (forkIO)
-import Control.Concurrent.STM (STM, TChan, atomically, orElse, readTChan, readTVar, registerDelay, retry, tryReadTChan)
+import Control.Concurrent.STM (TChan)
 import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (encode, object, (.=))
@@ -17,7 +17,6 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text, pack)
-import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import Handlers.Statuses (broadcastProjectStatus)
@@ -26,6 +25,7 @@ import Servant (Handler, Header, Headers, NoContent (..), addHeader, throwError)
 import Servant.API.ContentTypes (Accept (..), MimeRender (..))
 import Servant.Server (err500, errBody)
 import qualified Servant.Types.SourceT as S
+import qualified Sse
 import UserRepo (ReadRepoContext (..), withReadRepoTransaction)
 
 data EventStream
@@ -43,11 +43,11 @@ completion toasts then fire regardless of which page is open.
 stepStatusStreamHandler :: Handler (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (S.SourceT IO BS.ByteString))
 stepStatusStreamHandler = do
     busChan <- liftIO subscribe
-    let padding = sseComment $ "padding " <> pack (replicate 4096 ' ')
+    let padding = Sse.sseComment $ "padding " <> pack (replicate 4096 ' ')
     let source =
             S.fromStepT
                 ( S.Yield
-                    (sseComment "connected")
+                    (Sse.sseComment "connected")
                     ( S.Yield
                         padding
                         (S.Effect (streamLoop busChan))
@@ -73,49 +73,14 @@ projectStatusHandler projectId commit = do
     liftIO $ void $ forkIO $ broadcastProjectStatus projectId targetCommit Nothing
     pure NoContent
 
-heartbeatDelayMicros :: Int
-heartbeatDelayMicros = 30 * 1000000
-
-{- | Block on the snapshot broadcast channel, racing against a 30-second
-heartbeat.  A snapshot fires a @snapshot@ SSE event (burst-coalesced with
-anything already queued); a timeout fires an empty @heartbeat@.  No
-project or commit filtering: this is a global stream.
--}
 streamLoop :: TChan ProjectSnapshot -> IO (S.StepT IO BS.ByteString)
-streamLoop busChan = do
-    heartbeatDue <- registerDelay heartbeatDelayMicros
-    waitForEvent heartbeatDue
+streamLoop busChan =
+    Sse.broadcastLoop snapshotEvent busChan
   where
-    waitForEvent heartbeatDue = do
-        snapshots <-
-            atomically $
-                ( do
-                    first <- readTChan busChan
-                    rest <- drainTChan busChan
-                    pure $ Just (first : rest)
-                )
-                    `orElse` ( do
-                                due <- readTVar heartbeatDue
-                                if due then pure Nothing else retry
-                             )
-        case snapshots of
-            Nothing ->
-                return $
-                    S.Yield
-                        (sseEvent "heartbeat" (encode (object [])))
-                        (S.Effect (streamLoop busChan))
-            Just batch -> do
-                let events = map snapshotEvent batch
-                return $ yieldAll events (S.Effect (streamLoop busChan))
     snapshotEvent snapshot =
-        sseEvent "snapshot" (encodeSnapshot (Bus.projectId snapshot) (Bus.commit snapshot) (Bus.statuses snapshot))
-
-drainTChan :: TChan a -> STM [a]
-drainTChan chan = do
-    mItem <- tryReadTChan chan
-    case mItem of
-        Nothing -> return []
-        Just item -> (item :) <$> drainTChan chan
+        ( "snapshot"
+        , encodeSnapshot (Bus.projectId snapshot) (Bus.commit snapshot) (Bus.statuses snapshot)
+        )
 
 encodeSnapshot :: Int -> Text -> Map Int (Text, Maybe Text) -> LBS.ByteString
 encodeSnapshot projectId targetCommit statuses =
@@ -134,17 +99,3 @@ encodeSnapshot projectId targetCommit statuses =
                     (Map.toList statuses)
             ]
         )
-
-sseEvent :: Text -> LBS.ByteString -> BS.ByteString
-sseEvent eventName payload =
-    TE.encodeUtf8 ("event: " <> eventName <> "\n")
-        <> "data: "
-        <> LBS.toStrict payload
-        <> "\n\n"
-
-sseComment :: Text -> BS.ByteString
-sseComment text_ =
-    TE.encodeUtf8 (": " <> text_ <> "\n\n")
-
-yieldAll :: [BS.ByteString] -> S.StepT IO BS.ByteString -> S.StepT IO BS.ByteString
-yieldAll chunks rest = foldr S.Yield rest chunks

--- a/backend/src/Handlers/StatusStream.hs
+++ b/backend/src/Handlers/StatusStream.hs
@@ -3,30 +3,26 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Handlers.StatusStream (EventStream, stepStatusStreamHandler) where
+module Handlers.StatusStream (EventStream, stepStatusStreamHandler, projectStatusHandler, streamLoop) where
 
 import Bus (ProjectSnapshot, subscribe)
 import qualified Bus
 import Control.Concurrent (forkIO)
-import Control.Concurrent.Async (mapConcurrently_)
-import Control.Concurrent.STM (STM, TChan, atomically, newTChanIO, orElse, readTChan, readTVar, registerDelay, retry, tryReadTChan, writeTChan)
-import Control.Monad (void, when)
-
+import Control.Concurrent.STM (STM, TChan, atomically, orElse, readTChan, readTVar, registerDelay, retry, tryReadTChan)
+import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (encode, object, (.=))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
-import Data.Text (Text, pack, unpack)
+import Data.Text (Text, pack)
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
-import Handlers.Statuses (getRawStatusesWithPaths, partitionImmediateStatuses, resolveStepStatus)
+import Handlers.Statuses (broadcastProjectStatus)
 import Network.HTTP.Media ((//))
-
-import Servant (Handler, Header, Headers, addHeader, throwError)
+import Servant (Handler, Header, Headers, NoContent (..), addHeader, throwError)
 import Servant.API.ContentTypes (Accept (..), MimeRender (..))
 import Servant.Server (err500, errBody)
 import qualified Servant.Types.SourceT as S
@@ -34,139 +30,83 @@ import UserRepo (ReadRepoContext (..), withReadRepoTransaction)
 
 data EventStream
 
-data LocalStatusUpdate
-    = LocalSnapshot ProjectSnapshot
-    | LocalError Text
-
 instance Accept EventStream where
     contentType _ = "text" // "event-stream"
 
 instance MimeRender EventStream BS.ByteString where
     mimeRender _ = LBS.fromStrict
 
-stepStatusStreamHandler :: Int -> Maybe Text -> Handler (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (S.SourceT IO BS.ByteString))
-stepStatusStreamHandler projectId commit = do
-    eitherCtx <- liftIO $ withReadRepoTransaction $ \(ReadRepoContext repoPath hash) ->
-        let targetCommit = fromMaybe (pack hash) commit
-         in return (ReadRepoContext repoPath (unpack targetCommit))
-    ctx <-
-        case eitherCtx of
-            Left err -> throwError $ err500{errBody = TLE.encodeUtf8 (TL.pack err)}
-            Right c -> pure c
-    let targetCommit = pack (readCommitHash ctx)
-
-    localChan <- liftIO newTChanIO
+{- | A single app-global SSE stream carrying snapshot and heartbeat events
+for every project's steps, unfiltered.  Clients open this stream once;
+completion toasts then fire regardless of which page is open.
+-}
+stepStatusStreamHandler :: Handler (Headers '[Header "Cache-Control" Text, Header "X-Accel-Buffering" Text] (S.SourceT IO BS.ByteString))
+stepStatusStreamHandler = do
     busChan <- liftIO subscribe
-
-    -- Fork async status fetch and resolution; the initial SSE response
-    -- goes out immediately with an empty snapshot so the client is never
-    -- blocked on Nix evaluation.
-    liftIO $
-        void $
-            forkIO $ do
-                result <- getRawStatusesWithPaths projectId targetCommit
-                case result of
-                    Left err -> do
-                        putStrLn $ "Project status stream failed for project " ++ show projectId ++ ": " ++ err
-                        atomically $ writeTChan localChan (LocalError (pack err))
-                    Right (rawStatuses, outPaths) -> do
-                        let (initialStatuses, pendingStatuses) = partitionImmediateStatuses rawStatuses
-                        when (not (Map.null initialStatuses)) $ do
-                            stillCurrent <- statusStreamCommitStillCurrent commit targetCommit
-                            when stillCurrent $
-                                atomically $
-                                    writeTChan localChan (LocalSnapshot (Bus.ProjectSnapshot projectId targetCommit initialStatuses))
-                        when (not (Map.null pendingStatuses)) $
-                            publishResolvedStatuses localChan commit projectId ctx outPaths pendingStatuses
-
     let padding = sseComment $ "padding " <> pack (replicate 4096 ' ')
-    let emptySnapshot = encodeSnapshot projectId targetCommit Map.empty
     let source =
             S.fromStepT
                 ( S.Yield
                     (sseComment "connected")
                     ( S.Yield
                         padding
-                        ( S.Yield
-                            (sseEvent "snapshot" emptySnapshot)
-                            (S.Effect (streamLoop projectId commit localChan busChan))
-                        )
+                        (S.Effect (streamLoop busChan))
                     )
                 )
     pure $ addHeader "no-transform" $ addHeader "no" source
 
-publishResolvedStatuses :: TChan LocalStatusUpdate -> Maybe Text -> Int -> ReadRepoContext -> Map Int Text -> Map Int (Text, Maybe Text) -> IO ()
-publishResolvedStatuses updatesChan pinnedCommit projectId ctx outPaths statuses =
-    mapConcurrently_ publishOne (Map.toList statuses)
-  where
-    targetCommit = pack (readCommitHash ctx)
-
-    publishOne (sid, entry) = do
-        (sid', status_) <- resolveStepStatus ctx (fmap unpack $ Map.lookup sid outPaths) (sid, entry)
-        shouldPublish <- statusStreamCommitStillCurrent pinnedCommit targetCommit
-        when shouldPublish $
-            atomically $
-                writeTChan updatesChan (LocalSnapshot (Bus.ProjectSnapshot projectId targetCommit (Map.singleton sid' status_)))
-
-statusStreamCommitStillCurrent :: Maybe Text -> Text -> IO Bool
-statusStreamCommitStillCurrent pinnedCommit targetCommit =
-    case pinnedCommit of
-        Just _ -> return True
-        Nothing -> do
-            latest <- withReadRepoTransaction $ \(ReadRepoContext _ hash) -> return (pack hash)
-            return $ latest == Right targetCommit
+{- | Re-evaluate a project's step statuses and broadcast them on the global
+step status stream.  The target commit defaults to the current repo head
+when omitted; the evaluation runs in a forked thread so the request
+returns immediately.
+-}
+projectStatusHandler :: Int -> Maybe Text -> Handler NoContent
+projectStatusHandler projectId commit = do
+    targetCommit <-
+        case commit of
+            Just c -> pure c
+            Nothing -> do
+                result <- liftIO $ withReadRepoTransaction $ \(ReadRepoContext _ hash) -> return (pack hash)
+                case result of
+                    Left err -> throwError $ err500{errBody = TLE.encodeUtf8 (TL.pack err)}
+                    Right c -> pure c
+    liftIO $ void $ forkIO $ broadcastProjectStatus projectId targetCommit Nothing
+    pure NoContent
 
 heartbeatDelayMicros :: Int
 heartbeatDelayMicros = 30 * 1000000
 
-streamLoop :: Int -> Maybe Text -> TChan LocalStatusUpdate -> TChan ProjectSnapshot -> IO (S.StepT IO BS.ByteString)
-streamLoop projectId pinnedCommit localChan busChan = do
+{- | Block on the snapshot broadcast channel, racing against a 30-second
+heartbeat.  A snapshot fires a @snapshot@ SSE event (burst-coalesced with
+anything already queued); a timeout fires an empty @heartbeat@.  No
+project or commit filtering: this is a global stream.
+-}
+streamLoop :: TChan ProjectSnapshot -> IO (S.StepT IO BS.ByteString)
+streamLoop busChan = do
     heartbeatDue <- registerDelay heartbeatDelayMicros
     waitForEvent heartbeatDue
   where
     waitForEvent heartbeatDue = do
-        activity <-
+        snapshots <-
             atomically $
                 ( do
-                    firstLocal <- readTChan localChan
-                    localUpdates <- (firstLocal :) <$> drainTChan localChan
-                    busUpdates <- drainTChan busChan
-                    pure $ Just (localUpdates, busUpdates)
+                    first <- readTChan busChan
+                    rest <- drainTChan busChan
+                    pure $ Just (first : rest)
                 )
-                    `orElse` ( do
-                                firstBus <- readTChan busChan
-                                localUpdates <- drainTChan localChan
-                                busUpdates <- (firstBus :) <$> drainTChan busChan
-                                pure $ Just (localUpdates, busUpdates)
-                             )
                     `orElse` ( do
                                 due <- readTVar heartbeatDue
                                 if due then pure Nothing else retry
                              )
-
-        case activity of
+        case snapshots of
             Nothing ->
                 return $
                     S.Yield
-                        (sseEvent "heartbeat" (encode (object ["projectId" .= projectId])))
-                        (S.Effect (streamLoop projectId pinnedCommit localChan busChan))
-            Just (localUpdates, busUpdates) -> do
-                let localErrors = [err | LocalError err <- localUpdates]
-                let localSnapshots = [snapshot | LocalSnapshot snapshot <- localUpdates]
-                let matchingSnapshots = filter matchesSnapshot (localSnapshots ++ busUpdates)
-
-                case localErrors of
-                    (err : _) ->
-                        return $ S.Yield (sseEvent "status-error" (encode err)) S.Stop
-                    [] ->
-                        case matchingSnapshots of
-                            [] -> waitForEvent heartbeatDue
-                            snapshots -> do
-                                let events = map snapshotEvent snapshots
-                                return $ yieldAll events (S.Effect (streamLoop projectId pinnedCommit localChan busChan))
-    matchesSnapshot snapshot =
-        Bus.projectId snapshot == projectId && maybe True (== Bus.commit snapshot) pinnedCommit
-
+                        (sseEvent "heartbeat" (encode (object [])))
+                        (S.Effect (streamLoop busChan))
+            Just batch -> do
+                let events = map snapshotEvent batch
+                return $ yieldAll events (S.Effect (streamLoop busChan))
     snapshotEvent snapshot =
         sseEvent "snapshot" (encodeSnapshot (Bus.projectId snapshot) (Bus.commit snapshot) (Bus.statuses snapshot))
 
@@ -176,6 +116,7 @@ drainTChan chan = do
     case mItem of
         Nothing -> return []
         Just item -> (item :) <$> drainTChan chan
+
 encodeSnapshot :: Int -> Text -> Map Int (Text, Maybe Text) -> LBS.ByteString
 encodeSnapshot projectId targetCommit statuses =
     encode

--- a/backend/src/Handlers/StatusStream.hs
+++ b/backend/src/Handlers/StatusStream.hs
@@ -44,7 +44,7 @@ stepStatusStreamHandler :: Handler (Headers '[Header "Cache-Control" Text, Heade
 stepStatusStreamHandler = do
     busChan <- liftIO subscribe
     let padding = Sse.sseComment $ "padding " <> pack (replicate 4096 ' ')
-    let source =
+        source =
             S.fromStepT
                 ( S.Yield
                     (Sse.sseComment "connected")
@@ -66,10 +66,8 @@ projectStatusHandler projectId commit = do
         case commit of
             Just c -> pure c
             Nothing -> do
-                result <- liftIO $ withReadRepoTransaction $ \(ReadRepoContext _ hash) -> return (pack hash)
-                case result of
-                    Left err -> throwError $ err500{errBody = TLE.encodeUtf8 (TL.pack err)}
-                    Right c -> pure c
+                result <- liftIO $ withReadRepoTransaction $ \(ReadRepoContext _ hash) -> pure (pack hash)
+                either (\err -> throwError $ err500{errBody = TLE.encodeUtf8 (TL.pack err)}) pure result
     liftIO $ void $ forkIO $ broadcastProjectStatus projectId targetCommit Nothing
     pure NoContent
 
@@ -77,10 +75,7 @@ streamLoop :: TChan ProjectSnapshot -> IO (S.StepT IO BS.ByteString)
 streamLoop busChan =
     Sse.broadcastLoop snapshotEvent busChan
   where
-    snapshotEvent snapshot =
-        ( "snapshot"
-        , encodeSnapshot (Bus.projectId snapshot) (Bus.commit snapshot) (Bus.statuses snapshot)
-        )
+    snapshotEvent snapshot = ("snapshot", encodeSnapshot (Bus.projectId snapshot) (Bus.commit snapshot) (Bus.statuses snapshot))
 
 encodeSnapshot :: Int -> Text -> Map Int (Text, Maybe Text) -> LBS.ByteString
 encodeSnapshot projectId targetCommit statuses =

--- a/backend/src/Sse.hs
+++ b/backend/src/Sse.hs
@@ -35,6 +35,8 @@ broadcastLoop render chan = do
     heartbeatDue <- registerDelay heartbeatDelayMicros
     waitForEvent heartbeatDue
   where
+    loop = S.Effect (broadcastLoop render chan)
+
     waitForEvent heartbeatDue = do
         batch <-
             atomically $
@@ -49,13 +51,10 @@ broadcastLoop render chan = do
                              )
         case batch of
             Nothing ->
-                return $
-                    S.Yield
-                        (sseEvent "heartbeat" (encode (object [])))
-                        (S.Effect (broadcastLoop render chan))
-            Just values -> do
-                let events = map (uncurry sseEvent . render) values
-                return $ foldr S.Yield (S.Effect (broadcastLoop render chan)) events
+                return $ S.Yield (sseEvent "heartbeat" (encode (object []))) loop
+            Just values ->
+                return $ foldr S.Yield loop (map (uncurry sseEvent . render) values)
+
     drain chan = do
         mItem <- tryReadTChan chan
         case mItem of

--- a/backend/src/Sse.hs
+++ b/backend/src/Sse.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | SSE wire-format utilities shared by every server-sent stream: event
+framing, comment padding, and the heartbeat-racing broadcast loop.  The
+loop coalesces values queued since the last wake-up into one burst, and
+emits an empty @heartbeat@ event when the channel has been idle for 30
+seconds to keep the connection alive behind proxies.
+-}
+module Sse (broadcastLoop, heartbeatDelayMicros, sseComment, sseEvent) where
+
+import Control.Concurrent.STM (STM, TChan, atomically, orElse, readTChan, readTVar, registerDelay, retry, tryReadTChan)
+import Data.Aeson (encode, object)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import qualified Servant.Types.SourceT as S
+
+heartbeatDelayMicros :: Int
+heartbeatDelayMicros = 30 * 1000000
+
+sseEvent :: Text -> LBS.ByteString -> BS.ByteString
+sseEvent eventName payload =
+    TE.encodeUtf8 ("event: " <> eventName <> "\n")
+        <> "data: "
+        <> LBS.toStrict payload
+        <> "\n\n"
+
+sseComment :: Text -> BS.ByteString
+sseComment text_ =
+    TE.encodeUtf8 (": " <> text_ <> "\n\n")
+
+broadcastLoop :: (a -> (Text, LBS.ByteString)) -> TChan a -> IO (S.StepT IO BS.ByteString)
+broadcastLoop render chan = do
+    heartbeatDue <- registerDelay heartbeatDelayMicros
+    waitForEvent heartbeatDue
+  where
+    waitForEvent heartbeatDue = do
+        batch <-
+            atomically $
+                ( do
+                    first <- readTChan chan
+                    rest <- drain chan
+                    pure $ Just (first : rest)
+                )
+                    `orElse` ( do
+                                due <- readTVar heartbeatDue
+                                if due then pure Nothing else retry
+                             )
+        case batch of
+            Nothing ->
+                return $
+                    S.Yield
+                        (sseEvent "heartbeat" (encode (object [])))
+                        (S.Effect (broadcastLoop render chan))
+            Just values -> do
+                let events = map (uncurry sseEvent . render) values
+                return $ foldr S.Yield (S.Effect (broadcastLoop render chan)) events
+    drain chan = do
+        mItem <- tryReadTChan chan
+        case mItem of
+            Nothing -> return []
+            Just item -> (item :) <$> drain chan

--- a/backend/test/StatusStreamTest.hs
+++ b/backend/test/StatusStreamTest.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the global step-status stream: snapshot events for every
+project are delivered unfiltered from the shared broadcast bus, a new
+subscription replays snapshots broadcast just before it connected, and
+the stream stays silent (no polling or periodic events) in the absence
+of broadcasts.
+-}
+module Main (main) where
+
+import Bus (broadcastSnapshot, subscribe)
+import Control.Monad (unless)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Handlers.StatusStream (streamLoop)
+import Servant.Types.SourceT (StepT (..))
+import System.Timeout (timeout)
+
+main :: IO ()
+main = do
+    -- Nothing broadcast yet: a 1-second pull must time out rather than
+    -- emit any polling or periodic event.
+    silent <- timeout 1000000 (pullStep (streamLoop =<< subscribe))
+    assertEqual "no event without a broadcast" Nothing (fmap (const ()) silent)
+
+    -- Two projects broadcast on the bus; a subscription made afterwards
+    -- must replay both (no per-project filtering, no snapshots lost to a
+    -- connect race).
+    broadcastSnapshot 1 "abc123" (Map.singleton 1 ("success", Nothing))
+    broadcastSnapshot 2 "def456" (Map.singleton 2 ("running", Nothing))
+
+    m1 <- timeout 2000000 (pullStep (streamLoop =<< subscribe))
+    case m1 of
+        Nothing -> fail "first snapshot did not arrive"
+        Just Nothing -> fail "stream ended before first snapshot"
+        Just (Just (bytes1, pull1)) -> do
+            assertBool "first snapshot is a snapshot event" ("event: snapshot" `BS.isInfixOf` bytes1)
+            assertBool "first snapshot carries project id" ("\"projectId\":1" `BS.isInfixOf` bytes1)
+            m2 <- timeout 2000000 (pullStep pull1)
+            case m2 of
+                Nothing -> fail "second snapshot did not arrive"
+                Just Nothing -> fail "stream ended before second snapshot"
+                Just (Just (bytes2, _pull2)) -> do
+                    assertBool "second snapshot is a snapshot event" ("event: snapshot" `BS.isInfixOf` bytes2)
+                    assertBool "second snapshot carries project id" ("\"projectId\":2" `BS.isInfixOf` bytes2)
+
+-- | Pull one SSE event (or the stream end) from a step producer.
+pullStep :: IO (StepT IO BS.ByteString) -> IO (Maybe (BS.ByteString, IO (StepT IO BS.ByteString)))
+pullStep mstep = do
+    step <- mstep
+    case step of
+        Yield bs rest -> pure (Just (bs, pure rest))
+        Skip rest -> pullStep (pure rest)
+        Effect m -> pullStep m
+        Stop -> pure Nothing
+        Error e -> fail ("stream error: " ++ show e)
+
+assertBool :: String -> Bool -> IO ()
+assertBool label ok = unless ok (fail label)
+
+assertEqual :: (Eq a, Show a) => String -> a -> a -> IO ()
+assertEqual label expected actual
+    | actual == expected = pure ()
+    | otherwise = fail $ label ++ ": expected " ++ show expected ++ ", got " ++ show actual

--- a/frontend/ffi.js
+++ b/frontend/ffi.js
@@ -58,8 +58,6 @@ function openClusterStatusStream(app) {
 }
 
 let stepStatusSource = null;
-let stepStatusTargetKey = null;
-let stepStatusApplicationError = false;
 let agentTurnSource = null;
 let agentTurnTargetKey = null;
 const AGENT_TURN_INITIAL_RETRY_DELAY = 1000;
@@ -72,8 +70,6 @@ function closeStepStatusStream() {
     stepStatusSource.close();
     stepStatusSource = null;
   }
-  stepStatusTargetKey = null;
-  stepStatusApplicationError = false;
 }
 
 function closeAgentTurnStream() {
@@ -138,26 +134,11 @@ export function connectPorts(app) {
     }
   }
 
-  function openStepStatusStream({ projectId, commit }) {
-    const params = new URLSearchParams({ project_id: String(projectId) });
-    if (commit) {
-      params.set("commit", commit);
-    }
-
-    const url = `/backend/step-status-stream?${params.toString()}`;
-
-    if (
-      stepStatusSource &&
-      stepStatusTargetKey === url &&
-      stepStatusSource.readyState !== EventSource.CLOSED
-    ) {
+  function openStepStatusStream() {
+    if (stepStatusSource && stepStatusSource.readyState !== EventSource.CLOSED) {
       return;
     }
-
-    closeStepStatusStream();
-
-    stepStatusSource = new EventSource(url);
-    stepStatusTargetKey = url;
+    stepStatusSource = new EventSource("/backend/step-status-stream");
 
     stepStatusSource.addEventListener("snapshot", (event) => {
       try {
@@ -173,20 +154,7 @@ export function connectPorts(app) {
       } catch {}
     });
 
-    stepStatusSource.addEventListener("status-error", (event) => {
-      stepStatusApplicationError = true;
-      try {
-        emitToElm("error", JSON.parse(event.data));
-      } catch (err) {
-        emitToElm("error", `Failed to parse status error event: ${String(err)}`);
-      }
-    });
-
     stepStatusSource.onerror = () => {
-      if (stepStatusApplicationError) {
-        stepStatusApplicationError = false;
-        return;
-      }
       emitToElm("error", "Step status stream connection issue");
     };
   }
@@ -260,7 +228,6 @@ export function connectPorts(app) {
     closeDialog,
     hidePopover,
     copyToClipboard,
-    closeStepStatusStream,
     closeAgentTurnStream,
     zoomIframe,
     toggleTheme,
@@ -278,7 +245,7 @@ export function connectPorts(app) {
   }
 
   if (app.ports && app.ports.openStepStatusStream) {
-    app.ports.openStepStatusStream.subscribe(openStepStatusStream);
+    app.ports.openStepStatusStream.subscribe(() => openStepStatusStream());
   }
 
   if (app.ports && app.ports.openAgentTurnStream) {

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -264,7 +264,7 @@ loadProjects =
                                         try (route << Route.page << Route.project << mCommit << just) model
                                 in
                                 callApiMerge Model.updateProjectRecordList (projects << records) (Api.fetchProjects mCommit_ presets_ stepConfig_ |> Flow.map (Result.map sortProjects))
-                                    |> FlowError.foldResult (\_ -> Flow.pure ()) (\_ -> Flow.pure ())
+                                    |> ignoreResult
                                     |> Flow.seq (Flow.async replayStepStatusBuffer)
                             )
                 )
@@ -277,16 +277,9 @@ replayStepStatusBuffer =
     Flow.get
         |> Flow.andThen
             (\model ->
-                let
-                    applyOne ( stepId, ( commit, status ) ) =
-                        Flow.over
-                            (projects << records << success << each << tables << values << records << success << by .id (Just stepId) << runState)
-                            (applyStatusSnapshot commit status)
-                            |> Flow.seq (Flow.when (status == StatusSuccess) (runAndClearStepStatusHook stepId))
-                in
                 get stepStatusBuffer model
                     |> Dict.toList
-                    |> List.map applyOne
+                    |> List.map (\( stepId, ( commit, status ) ) -> updateStepStatus commit stepId status)
                     |> Flow.batchM
                     |> Flow.seq (Flow.setAll stepStatusBuffer Dict.empty)
             )
@@ -1082,6 +1075,13 @@ callApiMerge merge lens apiCall =
                         )
             )
 
+
+{-| Run a call for its side effects: keep @callApi@'s error toast, then
+discard the result on both branches.
+-}
+ignoreResult : FlowError Http.Error Model a -> Flow Model ()
+ignoreResult =
+    FlowError.foldResult (\_ -> Flow.pure ()) (\_ -> Flow.pure ())
 
 downloadFile : Int -> String -> List String -> Flow Model ()
 downloadFile stepId commit filePath =
@@ -3673,9 +3673,7 @@ finalizeChatTurn mError agentState =
 requestProjectStatus : Int -> Maybe String -> Flow Model ()
 requestProjectStatus projectId commit =
     callApi void (Api.refreshProjectStatus projectId commit)
-        |> FlowError.foldResult
-            (\_ -> Flow.pure ())
-            (\_ -> Flow.pure ())
+        |> ignoreResult
 
 
 listenAndProcessStepStatus : Flow Model Decode.Value

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -264,7 +264,8 @@ loadProjects =
                                         try (route << Route.page << Route.project << mCommit << just) model
                                 in
                                 callApiMerge Model.updateProjectRecordList (projects << records) (Api.fetchProjects mCommit_ presets_ stepConfig_ |> Flow.map (Result.map sortProjects))
-                                    |> FlowError.foldResult (\_ -> Flow.async replayStepStatusBuffer) (\_ -> Flow.pure ())
+                                    |> FlowError.foldResult (\_ -> Flow.pure ()) (\_ -> Flow.pure ())
+                                    |> Flow.seq (Flow.async replayStepStatusBuffer)
                             )
                 )
         )
@@ -281,6 +282,7 @@ replayStepStatusBuffer =
                         Flow.over
                             (projects << records << success << each << tables << values << records << success << by .id (Just stepId) << runState)
                             (applyStatusSnapshot commit status)
+                            |> Flow.seq (Flow.when (status == StatusSuccess) (runAndClearStepStatusHook stepId))
                 in
                 get stepStatusBuffer model
                     |> Dict.toList
@@ -2303,11 +2305,6 @@ saveProject projectId =
         |> FlowError.andThen (\_ -> refetchCommitHash |> Flow.return ())
 
 
-closeStepStatusStream : Flow Model ()
-closeStepStatusStream =
-    callJs "closeStepStatusStream" (\_ -> Encode.null) (Decode.succeed ()) ()
-
-
 agentChatId : String
 agentChatId =
     "agent-chat"
@@ -3673,16 +3670,28 @@ finalizeChatTurn mError agentState =
             flushed
 
 
-listenAndProcessStepStatus : Int -> Maybe String -> Flow Model Decode.Value
-listenAndProcessStepStatus projectId commit =
-    Flow.subscribe onStepStatusIn (Channels.stepStatus projectId commit)
+requestProjectStatus : Int -> Maybe String -> Flow Model ()
+requestProjectStatus projectId commit =
+    callApi void (Api.refreshProjectStatus projectId commit)
+        |> FlowError.foldResult
+            (\_ -> Flow.pure ())
+            (\_ -> Flow.pure ())
+
+
+listenAndProcessStepStatus : Flow Model Decode.Value
+listenAndProcessStepStatus =
+    Flow.subscribe onStepStatusIn Channels.stepStatus
 
 
 onStepStatusIn : Decode.Value -> Flow Model ()
 onStepStatusIn value =
     case Decode.decodeValue ApiDecode.stepStatusEvent value of
-        Ok (SSESnapshot { commit, steps }) ->
-            Flow.batchM (List.map (\s -> updateStepStatus commit s.stepId s.status) steps)
+        Ok (SSESnapshot { projectId, commit, steps }) ->
+            Flow.get
+                |> Flow.andThen
+                    (\model ->
+                        applySnapshot (stateUpdateVisible model projectId commit) commit steps
+                    )
 
         Ok SSEHeartbeat ->
             Flow.pure ()
@@ -3692,6 +3701,37 @@ onStepStatusIn value =
 
         Err err ->
             addToast False ("SSE Decode Error: " ++ Decode.errorToString err)
+
+
+stateUpdateVisible : Model -> Int -> String -> Bool
+stateUpdateVisible model snapshotProjectId snapshotCommit =
+    let
+        openProjectId =
+            try (route << Route.page << projectRoute << projectId) model
+
+        pinned =
+            try (route << Route.page << Route.project << mCommit << just) model
+
+        head =
+            try (commitHash << success) model
+
+        viewCommit =
+            if openProjectId == Just snapshotProjectId then
+                Maybe.orElse head pinned
+
+            else
+                head
+    in
+    Maybe.unwrap True ((==) snapshotCommit) viewCommit
+
+
+applySnapshot : Bool -> String -> List { stepId : Int, status : Status } -> Flow Model ()
+applySnapshot stateVisible commit steps =
+    if stateVisible then
+        Flow.batchM (List.map (\s -> updateStepStatus commit s.stepId s.status) steps)
+
+    else
+        Flow.batchM (List.filterMap (\s -> if s.status == StatusSuccess then Just (runAndClearStepStatusHook s.stepId) else Nothing) steps)
 
 
 updateStepStatus : String -> Int -> Status -> Flow Model ()

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -3706,18 +3706,12 @@ onStepStatusIn value =
 stateUpdateVisible : Model -> Int -> String -> Bool
 stateUpdateVisible model snapshotProjectId snapshotCommit =
     let
-        openProjectId =
-            try (route << Route.page << projectRoute << projectId) model
-
-        pinned =
-            try (route << Route.page << Route.project << mCommit << just) model
-
         head =
             try (commitHash << success) model
 
         viewCommit =
-            if openProjectId == Just snapshotProjectId then
-                Maybe.orElse head pinned
+            if try (route << Route.page << projectRoute << projectId) model == Just snapshotProjectId then
+                Maybe.orElse head (try (route << Route.page << Route.project << mCommit << just) model)
 
             else
                 head

--- a/frontend/src/Api/Api.elm
+++ b/frontend/src/Api/Api.elm
@@ -22,6 +22,7 @@ module Api.Api exposing
     , fetchStepConfig
     , fetchStepLog
     , fetchUserRepoInfo
+    , refreshProjectStatus
     , runStep
     , saveProject
     , saveProjectsBatch
@@ -324,6 +325,11 @@ unassignRecordFromProject projectId recordId =
 runStep : Int -> Maybe String -> Flow s (Result Http.Error ())
 runStep id commit =
     stepAction "run-step" id commit
+
+
+refreshProjectStatus : Int -> Maybe String -> Flow s (Result Http.Error ())
+refreshProjectStatus projectId commit =
+    request "POST" (appendCommitQuery ("/backend/project-status?project_id=" ++ String.fromInt projectId) commit) Http.emptyBody
 
 
 stopStep : Int -> Maybe String -> Flow s (Result Http.Error ())

--- a/frontend/src/Channels.elm
+++ b/frontend/src/Channels.elm
@@ -5,9 +5,9 @@ import Json.Decode
 import Ports
 
 
-stepStatus : Int -> Maybe String -> Channel s Json.Decode.Value
-stepStatus projectId commit =
-    Channel.connect Ports.stepStatusIn (\_ -> Ports.openStepStatusStream { projectId = projectId, commit = commit })
+stepStatus : Channel s Json.Decode.Value
+stepStatus =
+    Channel.connect Ports.stepStatusIn (\_ -> Ports.openStepStatusStream {})
 
 
 agentTurn : String -> Channel s Json.Decode.Value

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -11,7 +11,7 @@ import Http
 import Json.Decode as Decode
 import Maybe.Extra as Maybe
 import Model.Core exposing (Flags, Model, initialModel)
-import Model.Lenses exposing (commitHash, currentProject, currentProjectId, gutterDrag, mCommit, mHighlight, now, presets, projectStepRecords, projects, records, route, runState, stepConfig, userRepoInfo)
+import Model.Lenses exposing (commitHash, currentProjectId, gutterDrag, mCommit, mHighlight, now, presets, projectStepRecords, projects, records, route, runState, stepConfig, userRepoInfo)
 import Ports
 import Route exposing (Route)
 import Specs
@@ -62,6 +62,7 @@ initializeWorkspace =
         |> Flow.seq Actions.loadProjects
         |> Flow.seq (Flow.performTask Time.now |> Flow.andThen (Flow.setAll now))
         |> Flow.seq (Flow.async Actions.startClusterStatusStream)
+        |> Flow.seq (Flow.async Actions.listenAndProcessStepStatus)
 
 
 applyRouteFromUrl : Bool -> Url -> Flow Model ()
@@ -142,10 +143,7 @@ applyRoute forceRevealHighlight newRoute =
                                 Flow.when (currentRoute_ == newRoute) <|
                                     case newRoute.page of
                                         Route.Project { projectId, mHighlight, mCommit } ->
-                                            Flow.ifHas
-                                                (currentProject << success)
-                                                (\_ -> Flow.async <| Actions.listenAndProcessStepStatus projectId mCommit)
-                                                Actions.closeStepStatusStream
+                                            Actions.requestProjectStatus projectId mCommit
                                                 |> Flow.seq
                                                     (case mHighlight of
                                                         Just highlight ->
@@ -161,12 +159,10 @@ applyRoute forceRevealHighlight newRoute =
                                                 |> Flow.seq (Actions.syncCompareFromRoute newRoute)
 
                                         Route.Artifact _ ->
-                                            Actions.closeStepStatusStream
-                                                |> Flow.seq (Actions.syncCompareFromRoute newRoute)
+                                            Actions.syncCompareFromRoute newRoute
 
                                         Route.Home ->
-                                            Actions.closeStepStatusStream
-                                                |> Flow.seq (Actions.syncCompareFromRoute newRoute)
+                                            Actions.syncCompareFromRoute newRoute
 
                                         Route.NotFound _ ->
                                             Actions.syncCompareFromRoute newRoute

--- a/frontend/src/Ports.elm
+++ b/frontend/src/Ports.elm
@@ -10,7 +10,7 @@ port ffiOut : { key : String, fn : String, value : Json.Encode.Value } -> Cmd ms
 port ffiIn : ({ key : String, value : Json.Decode.Value } -> msg) -> Sub msg
 
 
-port openStepStatusStream : { projectId : Int, commit : Maybe String } -> Cmd msg
+port openStepStatusStream : {} -> Cmd msg
 
 
 port stepStatusIn : (Json.Decode.Value -> msg) -> Sub msg


### PR DESCRIPTION
## Problem
Success toasts only appeared when opening the project they belonged to: SSE status streams were scoped per project, so a step completing while its project was closed was never delivered.

## Change
- `step-status-stream` now serves every project's snapshots over one app-lifetime SSE connection (no project/commit filter, no per-connection evaluation).
- `POST /project-status?project_id=&commit=` re-evaluates one project's statuses and broadcasts them on the global stream; project pages trigger it instead of reconnecting a per-project stream.
- `Bus.subscribe` replays a bounded history (256) of recent snapshots, closing the subscribe-vs-broadcast race and reconnect loss.
- Frontend subscribes once at startup; pinned/head commit gating keeps table state correct while success hooks still fire, so completion toasts appear immediately on any page.
- Shared `Sse` module folds the duplicated SSE framing/heartbeat loop across cluster/status/agent streams; `SseStream` aliases the repeated endpoint type.

## Verification
- `cabal build all` clean (`-Wall`), all 3 test suites pass incl. new `status-stream` (fan-out, replay, silence).
- `elm make` clean; elm-review identical to main; `node --check ffi.js`; fourmolu-clean.
- Not smoke-tested end-to-end (needs cluster + dev-config).
