### PR TITLE
Browse and edit source files inside the step edit form

### DIFF
--- a/backend/src/Handlers/Store.hs
+++ b/backend/src/Handlers/Store.hs
@@ -249,6 +249,7 @@ getMimeType path = do
 
 mimeTypeByExtension :: FilePath -> Maybe Text
 mimeTypeByExtension path = case map toLower (takeExtension path) of
+    ".txt" -> Just "text/plain"
     ".css" -> Just "text/css"
     ".js" -> Just "application/javascript"
     ".mjs" -> Just "application/javascript"

--- a/frontend/src/Actions.elm
+++ b/frontend/src/Actions.elm
@@ -530,6 +530,11 @@ upsertStep spec =
                                                 |> Flow.seq loadProjects
 
                                         ( Just stepId, _ ) ->
+                                            let
+                                                srcFilePaths =
+                                                    try (lens << recordById stepId << srcFiles) model
+                                                        |> Maybe.unwrap [] (Model.srcFileChangePaths [])
+                                            in
                                             Flow.try (lens << recordById stepId << args)
                                                 (\originalArgs ->
                                                     let
@@ -544,9 +549,16 @@ upsertStep spec =
 
                                                                     else
                                                                         r.runState
+                                                                , srcFiles = Model.closeDirectoryFileViews r.srcFiles
+                                                                , srcFileDraft = r.srcFileDraft
+                                                                , srcFileWriting = r.srcFileWriting
                                                             }
+
+                                                        saveSrcFiles =
+                                                            saveSrcFileChanges stepId srcFilePaths
+                                                                |> Flow.return ()
                                                     in
-                                                    saveExistingRecord lens edited_ mergeFn spec
+                                                    saveExistingRecordWith saveSrcFiles lens edited_ mergeFn spec
                                                 )
                                 )
                         )
@@ -571,7 +583,12 @@ endRecordEdit lens =
 
 
 saveExistingRecord : A_Traversal Model (Table (BaseRecord a)) -> BaseRecord a -> (BaseRecord a -> BaseRecord a) -> TableSpec (BaseRecord a) -> Flow Model ()
-saveExistingRecord lens record mergeFn spec =
+saveExistingRecord =
+    saveExistingRecordWith (Flow.pure ())
+
+
+saveExistingRecordWith : Flow Model () -> A_Traversal Model (Table (BaseRecord a)) -> BaseRecord a -> (BaseRecord a -> BaseRecord a) -> TableSpec (BaseRecord a) -> Flow Model ()
+saveExistingRecordWith beforeRequest lens record mergeFn spec =
     let
         clearUpdating =
             Flow.forAll now
@@ -592,6 +609,7 @@ saveExistingRecord lens record mergeFn spec =
             )
         )
         |> Flow.seq (endRecordEdit lens)
+        |> Flow.seq beforeRequest
         |> Flow.seq
             (callApi void (Api.saveRecord spec record)
                 |> FlowError.foldResult (always clearUpdating) (always clearUpdating)
@@ -1823,25 +1841,107 @@ toggleSrcEntry recordId mOpen path =
 
 updateSrcFileContent : Int -> List String -> String -> Flow Model ()
 updateSrcFileContent recordId path content =
-    Flow.setAll (currentProject << success << tables << values << srcFilesFileEditedContentAt recordId path) (Just content)
-
-
-saveSrcFile : Int -> List String -> Flow Model ()
-saveSrcFile recordId path =
     let
         allStepTables =
             currentProject << success << tables << values
     in
-    Flow.whenHas (allStepTables << srcFilesFileEditedContentAt recordId path << just) <|
-        \content ->
+    Flow.forAll (allStepTables << srcFilesFileContentAt recordId path << success) <|
+        \savedContent ->
+            Flow.setAll (allStepTables << srcFilesFileEditedContentAt recordId path)
+                (if content == savedContent then
+                    Nothing
+
+                 else
+                    Just content
+                )
+
+
+saveSrcFileChange : Int -> List String -> Flow Model ()
+saveSrcFileChange recordId path =
+    let
+        allStepTables =
+            currentProject << success << tables << values
+
+        fileTraversal =
+            allStepTables << srcFilesItemAtPath recordId path << file
+
+        saveContent isNew content =
             predictSrcFileChange recordId
                 path
-                (Flow.setAll (allStepTables << srcFilesFileContentAt recordId path) (Success content)
-                    |> Flow.seq (Flow.setAll (allStepTables << srcFilesFileEditedContentAt recordId path) Nothing)
-                    |> Flow.seq (Flow.setAll (allStepTables << plainLineCountAt Route.Source recordId path) (Model.countLines content))
-                    |> Flow.seq (Flow.setAll (allStepTables << srcFilesFileIsViewingAt recordId path) False)
+                (Flow.over fileTraversal
+                    (\file_ ->
+                        { file_
+                            | content = Success content
+                            , size = String.length content
+                            , plainLineCount = Model.countLines content
+                            , editedContent = Nothing
+                            , isNew = False
+                        }
+                    )
                 )
-                (Api.saveSrcFile recordId path content)
+                (if isNew then
+                    Api.createSrcFile recordId path content
+
+                 else
+                    Api.saveSrcFile recordId path content
+                )
+    in
+    Flow.forAll fileTraversal <|
+        \file_ ->
+            if file_.isDeleted then
+                predictSrcFileChange recordId
+                    path
+                    (setSrcFileEntry recordId path Nothing)
+                    (Api.deleteSrcFile recordId path)
+
+            else
+                let
+                    contentToSave =
+                        if file_.isNew then
+                            Maybe.orElse file_.editedContent (ApiData.toMaybe file_.content)
+
+                        else
+                            file_.editedContent
+                in
+                Maybe.unwrap (Flow.pure ()) (saveContent file_.isNew) contentToSave
+
+
+saveSrcFileChanges : Int -> List (List String) -> Flow Model Bool
+saveSrcFileChanges recordId paths =
+    case paths of
+        [] ->
+            Flow.pure True
+
+        path :: remaining ->
+            let
+                allStepTables =
+                    currentProject << success << tables << values
+
+                unsavedFile =
+                    allStepTables
+                        << srcFilesItemAtPath recordId path
+                        << file
+                        << where_ Model.hasFileChanges
+            in
+            Flow.ifHas (allStepTables << recordById recordId << where_ .srcFileWriting)
+                (\_ -> Flow.pure False)
+                (saveSrcFileChange recordId path
+                    |> Flow.seq
+                        (Flow.ifHas unsavedFile
+                            (\_ -> Flow.pure False)
+                            (saveSrcFileChanges recordId remaining)
+                        )
+                )
+
+
+discardSrcFileChanges : Int -> Flow Model ()
+discardSrcFileChanges recordId =
+    let
+        stepRecord =
+            currentProject << success << tables << values << recordById recordId
+    in
+    Flow.over (stepRecord << srcFiles) Model.discardDirectoryFileChanges
+        |> Flow.seq (Flow.setAll (stepRecord << srcFileDraft) Nothing)
 
 
 setSrcFileDraft : Int -> Maybe Model.SrcFileDraft -> Flow Model ()
@@ -1898,14 +1998,17 @@ setSrcFileEntry recordId path entry =
                 (Dict.update name (always entry))
 
 
-createSrcFile : Int -> String -> String -> Flow Model ()
-createSrcFile recordId rawName content =
+stageSrcFile : Int -> String -> String -> Flow Model ()
+stageSrcFile recordId rawName content =
     case String.trim rawName of
         "" ->
             Flow.none
 
         fileName ->
             let
+                path =
+                    [ fileName ]
+
                 predictedSrcFile =
                     Model.File
                         { content = Success content
@@ -1918,22 +2021,50 @@ createSrcFile recordId rawName content =
                         , delimitedGrid = Nothing
                         , plainLineCount = Model.countLines content
                         , editedContent = Nothing
+                        , isNew = True
+                        , isDeleted = False
                         }
+
+                stagedItem =
+                    currentProject << success << tables << values << srcFilesItemAtPath recordId path
+
+                rootChildren =
+                    currentProject << success << tables << values << srcFilesChildrenAt recordId [] << success
             in
-            predictSrcFileChange recordId
-                [ fileName ]
-                (setSrcFileEntry recordId [ fileName ] (Just predictedSrcFile)
-                    |> Flow.seq (setSrcFileDraft recordId Nothing)
+            Flow.ifHas rootChildren
+                (\_ ->
+                    Flow.ifHas stagedItem
+                        (\_ -> Flow.pure ())
+                        (setSrcFileEntry recordId path (Just predictedSrcFile)
+                            |> Flow.seq (setSrcFileDraft recordId Nothing)
+                        )
                 )
-                (Api.createSrcFile recordId [ fileName ] content)
+                (Flow.pure ())
 
 
-deleteSrcFile : Int -> List String -> Flow Model ()
-deleteSrcFile recordId path =
-    predictSrcFileChange recordId
-        path
-        (setSrcFileEntry recordId path Nothing)
-        (Api.deleteSrcFile recordId path)
+stageSrcFileDeletion : Int -> List String -> Flow Model ()
+stageSrcFileDeletion recordId path =
+    let
+        allStepTables =
+            currentProject << success << tables << values
+
+        fileTraversal =
+            allStepTables << srcFilesItemAtPath recordId path << file
+    in
+    Flow.forAll fileTraversal <|
+        \file_ ->
+            if file_.isNew then
+                setSrcFileEntry recordId path Nothing
+
+            else
+                Flow.over fileTraversal (\current -> { current | isDeleted = True, view = Model.closeFileView current.view })
+
+
+restoreSrcFile : Int -> List String -> Flow Model ()
+restoreSrcFile recordId path =
+    Flow.over
+        (currentProject << success << tables << values << srcFilesItemAtPath recordId path << file)
+        (\file_ -> { file_ | isDeleted = False })
 
 
 registerStepStatusHook : Int -> Flow Model () -> Flow Model ()

--- a/frontend/src/Api/Decode.elm
+++ b/frontend/src/Api/Decode.elm
@@ -307,6 +307,8 @@ directoryItem fileView =
                                 , delimitedGrid = Nothing
                                 , plainLineCount = 1
                                 , editedContent = Nothing
+                                , isNew = False
+                                , isDeleted = False
                                 }
                             )
                         )

--- a/frontend/src/Model/Core.elm
+++ b/frontend/src/Model/Core.elm
@@ -953,6 +953,8 @@ type alias DirectoryFile =
     , delimitedGrid : Maybe DelimitedGrid
     , plainLineCount : Int
     , editedContent : Maybe String
+    , isNew : Bool
+    , isDeleted : Bool
     }
 
 
@@ -970,33 +972,123 @@ type DirectoryItem
     | Folder DirectoryFolder
 
 
+hasFileChanges : DirectoryFile -> Bool
+hasFileChanges file_ =
+    file_.isNew || file_.isDeleted || Maybe.isJust file_.editedContent
+
+
+srcFileChangePaths : List String -> DirectoryFolder -> List (List String)
+srcFileChangePaths parent folder_ =
+    folder_.children
+        |> ApiData.toMaybe
+        |> Maybe.unwrap []
+            (Dict.toList
+                >> List.concatMap
+                    (\( name, item ) ->
+                        let
+                            path =
+                                parent ++ [ name ]
+                        in
+                        case item of
+                            File file_ ->
+                                if hasFileChanges file_ then
+                                    [ path ]
+
+                                else
+                                    []
+
+                            Folder child ->
+                                srcFileChangePaths path child
+                    )
+            )
+
+
+closeDirectoryFileViews : DirectoryFolder -> DirectoryFolder
+closeDirectoryFileViews folder_ =
+    { folder_ | children = ApiData.map (Dict.map (always closeDirectoryFileView)) folder_.children }
+
+
+closeDirectoryFileView : DirectoryItem -> DirectoryItem
+closeDirectoryFileView item =
+    case item of
+        File file_ ->
+            File { file_ | view = closeFileView file_.view }
+
+        Folder child ->
+            Folder (closeDirectoryFileViews child)
+
+
+closeFileView : FileView -> FileView
+closeFileView view_ =
+    { view_ | isViewing = False }
+
+
+discardDirectoryFileChanges : DirectoryFolder -> DirectoryFolder
+discardDirectoryFileChanges folder_ =
+    { folder_
+        | children =
+            ApiData.map
+                (Dict.toList
+                    >> List.filterMap
+                        (\( name, item ) ->
+                            case item of
+                                File file_ ->
+                                    if file_.isNew then
+                                        Nothing
+
+                                    else
+                                        Just ( name, File { file_ | editedContent = Nothing, isDeleted = False, view = closeFileView file_.view } )
+
+                                Folder child ->
+                                    Just ( name, Folder (discardDirectoryFileChanges child) )
+                        )
+                    >> Dict.fromList
+                )
+                folder_.children
+    }
+
+
 updateDirectoryChildren : Dict String DirectoryItem -> Dict String DirectoryItem -> Dict String DirectoryItem
 updateDirectoryChildren fetched previous =
-    Dict.map
-        (\key fetchedItem ->
-            case ( fetchedItem, Dict.get key previous ) of
-                ( File new, Just (File old) ) ->
-                    File
-                        { new
-                            | content = old.content
-                            , view = old.view
-                            , delimitedGrid = old.delimitedGrid
-                            , plainLineCount = old.plainLineCount
-                            , editedContent = old.editedContent
-                        }
+    Dict.union
+        (Dict.map
+            (\key fetchedItem ->
+                case ( fetchedItem, Dict.get key previous ) of
+                    ( File new, Just (File old) ) ->
+                        File
+                            { new
+                                | content = old.content
+                                , view = old.view
+                                , delimitedGrid = old.delimitedGrid
+                                , plainLineCount = old.plainLineCount
+                                , editedContent = old.editedContent
+                                , isDeleted = old.isDeleted
+                            }
 
-                ( Folder new, Just (Folder old) ) ->
-                    Folder
-                        { new
-                            | children = old.children
-                            , expanded = old.expanded
-                            , extras = old.extras
-                        }
+                    ( Folder new, Just (Folder old) ) ->
+                        Folder
+                            { new
+                                | children = old.children
+                                , expanded = old.expanded
+                                , extras = old.extras
+                            }
 
-                _ ->
-                    fetchedItem
+                    _ ->
+                        fetchedItem
+            )
+            fetched
         )
-        fetched
+        (Dict.filter (always directoryItemIsNew) previous)
+
+
+directoryItemIsNew : DirectoryItem -> Bool
+directoryItemIsNew item =
+    case item of
+        File file_ ->
+            file_.isNew
+
+        Folder _ ->
+            False
 
 
 type alias ColumnMeta =

--- a/frontend/src/View/FileBrowser.elm
+++ b/frontend/src/View/FileBrowser.elm
@@ -19,7 +19,7 @@ import Json.Decode as Decode
 import List.Extra as List
 import Maybe.Extra as Maybe
 import Model.Core exposing (CompareSelection, CompareSource(..), DirectoryItem(..), FileChunk, Model, ScrollMetrics, SeekDirection(..), SeekWindow, Status(..), StepRecord, plainLineHeight, windowLineCount, windowStartLine)
-import Model.Lenses exposing (compareSelecting, compareState, currentProject, currentProjectId, fileZoomAt, gutterDrag, mCommit, mHighlight, mimeType, recordById, route, srcFileWriting, tables)
+import Model.Lenses exposing (compareSelecting, compareState, currentProject, currentProjectId, fileZoomAt, gutterDrag, mHighlight, mimeType, recordById, route, srcFileWriting, tables)
 import Model.Shadow as Shadow exposing (StepType, WithSrcFiles(..))
 import Model.TableSpec exposing (StepSpec)
 import Route
@@ -156,11 +156,6 @@ viewSrcFilesSection model stepType spec step =
         hasSrcFiles =
             has (Shadow.derivation << snd << where_ ((==) WithSrcFiles)) stepType
 
-        isLocked =
-            has (route << Route.page << Route.project << mCommit << just) model
-
-        mEditableId =
-            Maybe.filter (always (not isLocked)) step.id
 
         writePending =
             step.srcFileWriting
@@ -184,15 +179,15 @@ viewSrcFilesSection model stepType spec step =
                         ]
                         [ icon True symbol ]
                 )
-                mEditableId
+                step.id
 
         createForm =
-            case ( mEditableId, step.srcFileDraft ) of
+            case ( step.id, step.srcFileDraft ) of
                 ( Just recordId, Just draft ) ->
                     Html.form
                         [ class "src-file-create src-file-editor"
                         , Html.Events.preventDefaultOn "submit"
-                            (Decode.succeed ( Actions.createSrcFile recordId draft.name draft.content, True ))
+                            (Decode.succeed ( Actions.stageSrcFile recordId draft.name draft.content, True ))
                         ]
                         [ Html.div [ class "src-file-name-row" ]
                             [ Html.input
@@ -246,7 +241,7 @@ viewSrcFilesSection model stepType spec step =
                     spec
                     step.id
                     (Maybe.map SrcDir step.id)
-                    isLocked
+                    False
                     []
                     "directory-view"
                     (case step.srcFiles.children of
@@ -338,7 +333,7 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
                     has (mimeType << just << where_ (String.startsWith "image/")) file
 
                 canView =
-                    file.viewable || file.seekable || isImage
+                    not file.isDeleted && (file.viewable || file.seekable || isImage)
 
                 isHtml =
                     has (mimeType << just << where_ (String.startsWith "text/html")) file
@@ -347,7 +342,7 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
                     has (mimeType << just << where_ ((==) "chemical/x-pdb")) file
 
                 mCompareSelection =
-                    if file.viewable || isImage then
+                    if not file.isDeleted && (file.viewable || isImage) then
                         Maybe.map2 (\pid -> compareSelectionFor pid itemName file.mimeType path)
                             (try currentProjectId model)
                             mDirCtx
@@ -380,19 +375,41 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
 
                     else
                         "description"
+
+                isEditableSrcFile =
+                    has (just << srcDir) mDirCtx
+
+                fileActionLabel =
+                    if file.view.isViewing then
+                        "Close " ++ itemName
+
+                    else if isEditableSrcFile then
+                        "Edit " ++ itemName
+
+                    else
+                        "View " ++ itemName
             in
             Html.div [ class "directory-file-container" ]
                 [ Html.div [ class "directory-file", id anchor ]
                     [ icon True fileIcon
                     , Html.div [ class "file-name-container" ]
                         [ Html.span [ class "file-name" ] [ Html.text itemName ]
-                        , Html.nothing
+                        , if isEditableSrcFile && file.isNew then
+                            Html.span [ class "src-file-change-status is-new" ] [ Html.text "New" ]
+
+                          else if isEditableSrcFile && file.isDeleted then
+                            Html.span [ class "src-file-change-status is-deleted" ] [ Html.text "Deleted" ]
+
+                          else
+                            Html.viewIf (isEditableSrcFile && Maybe.isJust file.editedContent) <|
+                                Html.span [ class "src-file-change-status" ] [ Html.text "Changed" ]
                         , Html.span [ class "directory-item-meta" ] [ Html.text (Filesize.formatBase2 file.size) ]
                         ]
                     , Html.div [ class "file-actions" ]
                         [ Html.viewIf canView <|
                             Html.button
                                 [ class "dir-item-icon-btn"
+                                , Html.Attributes.title fileActionLabel
                                 , disabled (srcWritePending model mDirCtx)
                                 , Html.Events.onClick
                                     (case mDirCtx of
@@ -406,7 +423,7 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
                                             Flow.pure ()
                                     )
                                 ]
-                                [ icon True "visibility" ]
+                                [ icon True (if isEditableSrcFile then "edit" else "visibility") ]
                         , externalArtifactUrl
                             |> Html.viewMaybe
                                 (\url ->
@@ -428,13 +445,23 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
                         , viewCompareButton model mCompareSelection
                         , case ( mDirCtx, isLocked ) of
                             ( Just (SrcDir recordId), False ) ->
-                                Html.button
-                                    [ class "dir-item-icon-btn"
-                                    , Html.Attributes.title "Delete"
-                                    , disabled (srcWritePending model mDirCtx)
-                                    , Html.Events.onClick (Actions.deleteSrcFile recordId path)
-                                    ]
-                                    [ icon True "delete" ]
+                                if file.isDeleted then
+                                    Html.button
+                                        [ class "dir-item-icon-btn"
+                                        , Html.Attributes.title "Restore"
+                                        , disabled (srcWritePending model mDirCtx)
+                                        , Html.Events.onClick (Actions.restoreSrcFile recordId path)
+                                        ]
+                                        [ icon True "restore_from_trash" ]
+
+                                else
+                                    Html.button
+                                        [ class "dir-item-icon-btn"
+                                        , Html.Attributes.title "Delete"
+                                        , disabled (srcWritePending model mDirCtx)
+                                        , Html.Events.onClick (Actions.stageSrcFileDeletion recordId path)
+                                        ]
+                                        [ icon True "delete" ]
 
                             _ ->
                                 Html.nothing
@@ -548,7 +575,7 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
                                     mEditRecordId =
                                         mDirCtx
                                             |> Maybe.andThen (try srcDir)
-                                            |> Maybe.filter (always (not isLocked && Maybe.isNothing mSelectedRange))
+                                            |> Maybe.filter (always (Maybe.isNothing mSelectedRange))
 
                                     viewContent text =
                                         let
@@ -595,15 +622,6 @@ viewDirectoryItemWithPath model spec mRecordId mDirCtx isLocked directoryPath it
                                                 , readonly writePending
                                                 ]
                                                 []
-                                            , Html.viewIf changed <|
-                                                Html.div [ class "src-file-actions" ]
-                                                    [ Html.button
-                                                        [ class "btn"
-                                                        , disabled writePending
-                                                        , Html.Events.onClick (Actions.saveSrcFile recordId path)
-                                                        ]
-                                                        [ Html.text "Save" ]
-                                                    ]
                                             ]
                                 in
                                 Html.div [ class "file-viewer" ]

--- a/frontend/src/View/Main.elm
+++ b/frontend/src/View/Main.elm
@@ -41,7 +41,6 @@ view model =
                         , srcFilesSection = \_ -> Html.nothing
                         , onRecordClick = .id >> Maybe.map (\id -> Actions.goToRoute (Route.fromPage (Route.Project { projectId = id, mHighlight = Nothing, mCommit = Nothing, mCompare = Nothing })))
                         , isOpen = always False
-                        , isSrcOpen = always False
                         }
                 }
     in

--- a/frontend/src/View/Shadow.elm
+++ b/frontend/src/View/Shadow.elm
@@ -94,7 +94,7 @@ viewProject model proj =
                                 |> Maybe.filter (.id >> (==) proj.id)
                     in
                     Html.viewIf (not isReadOnly)
-                        (Maybe.map2 (\spec -> viewAddOrEditRecordForm model spec (get Lenses.projects model))
+                        (Maybe.map2 (\spec -> viewAddOrEditRecordForm model spec (get Lenses.projects model) Html.nothing)
                             mProjectSpec
                             mEditedProject
                             |> Maybe.withDefault Html.nothing
@@ -282,5 +282,4 @@ viewSection model sectionName entry steps =
                 record.id
                     |> Maybe.map (\id -> Actions.toggleOutputEntry id Nothing [] |> Flow.map (always ()))
         , isOpen = \r -> TableSpec.getDirectoryView spec r |> Maybe.map .expanded |> Maybe.withDefault False
-        , isSrcOpen = \r -> TableSpec.getSrcFilesView spec r |> Maybe.map .expanded |> Maybe.withDefault False
         }

--- a/frontend/src/View/Table.elm
+++ b/frontend/src/View/Table.elm
@@ -87,10 +87,9 @@ viewTable :
     , srcFilesSection : BaseRecord a -> Html (Flow Model ())
     , onRecordClick : BaseRecord a -> Maybe (Flow Model ())
     , isOpen : BaseRecord a -> Bool
-    , isSrcOpen : BaseRecord a -> Bool
     }
     -> Html (Flow Model ())
-viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordActions, directorySection, srcFilesSection, onRecordClick, isOpen, isSrcOpen } =
+viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordActions, directorySection, srcFilesSection, onRecordClick, isOpen } =
     let
         lens =
             TableSpec.getLens spec
@@ -122,18 +121,44 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
         mProjectId =
             try currentProjectId model
 
+        recordIsEditing record =
+            Maybe.unwrap False
+                (\editedRecord -> editedRecord.id == record.id && record.id /= Nothing)
+                table.edited
+
+        sourceFilesNeedLoading record =
+            case Maybe.map .children (TableSpec.getSrcFilesView spec record) of
+                Just NotAsked ->
+                    True
+
+                Just (Error _) ->
+                    True
+
+                _ ->
+                    False
+
+        toggleRecordEditor record =
+            let
+                loadSourceFiles =
+                    if sourceFilesNeedLoading record then
+                        Maybe.unwrap (Flow.pure ())
+                            (\recordId -> Actions.toggleSrcEntry recordId (Just True) [] |> Flow.return ())
+                            record.id
+
+                    else
+                        Flow.pure ()
+            in
+            Actions.toggleAddOrEditRecordForm spec record.id
+                |> Flow.seq loadSourceFiles
+
         recordActions =
             [ -- Directory button
               { shouldShow = \record -> TableSpec.getStatus spec record == Success StatusSuccess
               , render = \record -> Html.viewMaybe (dirButton (isOpen record) []) record.id
               }
-            , -- Source directory button
-              { shouldShow = \record -> TableSpec.getSrcFilesView spec record /= Nothing
-              , render = \record -> Html.viewMaybe (dirCodeButton (isSrcOpen record) []) record.id
-              }
             , -- Edit button
               { shouldShow = \record -> not isReadOnly && record.id /= Nothing
-              , render = \record -> viewIconButtonWithTooltip "edit" True "Edit" <| Actions.toggleAddOrEditRecordForm spec record.id
+              , render = \record -> viewIconButtonWithTooltip "edit" True "Edit" <| toggleRecordEditor record
               }
             , -- Share button (shareable only)
               { shouldShow = \record -> TableSpec.getShareable spec record && record.id /= Nothing
@@ -319,13 +344,7 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                         aStatus
 
                 recordNameEditable =
-                    let
-                        editing =
-                            Maybe.unwrap False
-                                (\r -> r.id == record.id && record.id /= Nothing)
-                                table.edited
-                    in
-                    if editing && table.nameEditOnly then
+                    if recordIsEditing record && table.nameEditOnly then
                         Html.input
                             [ type_ "text"
                             , value (Maybe.map .name table.edited |> Maybe.withDefault record.name)
@@ -426,7 +445,7 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                             , Html.span [ class "table-record-name" ]
                                 [ recordNameEditable
                                 , mtimeBadge
-                                , Html.viewIf (record.id == Nothing) <|
+                                , Html.viewIf (record.id == Nothing || record.isUpdating) <|
                                     Html.span [ class "pending-record-indicator", title "Saving..." ]
                                         [ iconCustom True "progress_activity" [ class "pending-record-icon" ]
                                         ]
@@ -468,15 +487,13 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                                 , mtimeBadge
                                 ]
                             ]
-                        , Html.viewIf (TableSpec.getSrcFilesView spec record |> Maybe.map .expanded |> Maybe.withDefault False) (srcFilesSection record)
                         , let
                             editing =
-                                Maybe.unwrap False
-                                    (\r -> r.id == record.id && record.id /= Nothing)
-                                    table.edited
+                                recordIsEditing record
                           in
                           Html.viewIf (editing && not table.nameEditOnly)
-                            (Html.viewMaybe (viewAddOrEditRecordForm model spec table)
+                            (Html.viewMaybe
+                                (\editedRecord -> viewAddOrEditRecordForm model spec table (srcFilesSection record) editedRecord)
                                 table.edited
                             )
                         , Html.viewIf (TableSpec.getDirectoryView spec record |> Maybe.map .expanded |> Maybe.withDefault False) (directorySection record)
@@ -594,7 +611,7 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
                                 -- This would be editing an existing record (handled elsewhere)
                                 Nothing
                         )
-                    |> Maybe.map (viewAddOrEditRecordForm model spec table)
+                    |> Maybe.map (viewAddOrEditRecordForm model spec table Html.nothing)
                     |> Maybe.withDefault Html.nothing
                 , Html.viewIf table.isOpen viewRecordsSection
                 ]
@@ -602,11 +619,15 @@ viewTable { model, spec, table, specificRecordActions, alwaysVisibleRecordAction
     viewContent
 
 
-viewAddOrEditRecordForm : Model -> TableSpec (BaseRecord a) -> Table (BaseRecord a) -> BaseRecord a -> Html (Flow Model ())
-viewAddOrEditRecordForm model spec table record =
+viewAddOrEditRecordForm : Model -> TableSpec (BaseRecord a) -> Table (BaseRecord a) -> Html (Flow Model ()) -> BaseRecord a -> Html (Flow Model ())
+viewAddOrEditRecordForm model spec table extraSection record =
     let
         editing =
             record.id /= Nothing && (table.addMode /= AddFromOtherProject)
+
+        savingInFlight =
+            try (records << success << by .id record.id) table
+                |> Maybe.unwrap False .isUpdating
 
         extraFields =
             case TableSpec.getTag spec of
@@ -722,6 +743,19 @@ viewAddOrEditRecordForm model spec table record =
                 ( True, _ ) ->
                     "Edit " ++ displayName
 
+        cancelAction =
+            let
+                endEdit =
+                    Actions.endRecordEdit (TableSpec.getLens spec)
+            in
+            case record.id of
+                Just recordId ->
+                    Actions.discardSrcFileChanges recordId
+                        |> Flow.seq endEdit
+
+                Nothing ->
+                    endEdit
+
         handleEnter =
             let
                 targetDecoder =
@@ -742,26 +776,32 @@ viewAddOrEditRecordForm model spec table record =
     in
     Html.div [ class "table-form-wrapper" ]
         [ Html.div [ formClasses, Events.on "keydown" handleEnter ]
-            [ Html.header [ class "form-header" ] [ Html.text headerTitle ]
-            , Html.viewMaybe
-                (\d -> Html.p [ class "form-intro" ] [ Html.text d ])
-                (if editing || table.addMode == AddNew then
-                    TableSpec.getDescription spec
+            [ Html.div [ class "loading-wrapper" ]
+                [ Html.header [ class "form-header" ] [ Html.text headerTitle ]
+                , Html.viewMaybe
+                    (\d -> Html.p [ class "form-intro" ] [ Html.text d ])
+                    (if editing || table.addMode == AddNew then
+                        TableSpec.getDescription spec
 
-                 else
-                    Nothing
-                )
-            , Html.div [ class "form-body" ]
-                [ Html.viewIf (not editing && TableSpec.getTag spec /= TagProjects) modeSelector
-                , Html.viewIf (not editing && table.addMode == AddFromOtherProject && TableSpec.getTag spec /= TagProjects) <| Html.Lazy.lazy viewSelectExisting table.selectExistingSteps
-                , Html.viewIf (not editing && table.addMode == AddNew || editing) nameInput
-                , Html.viewIf (not editing && table.addMode == AddNew || editing) noteInput
-                , Html.viewIf ((not editing && table.addMode == AddNew || editing) && not (List.isEmpty extraFields)) <|
-                    Html.div [ class "form-group" ] extraFields
-                , Html.div [ class "form-actions" ]
-                    [ Html.button [ id "save-button", Events.onClick (TableSpec.getUpsertRecord spec), class "btn", disabled table.isUpdating ] [ Html.text "Save" ]
-                    , Html.button [ Events.onClick (Actions.endRecordEdit (TableSpec.getLens spec)), class "btn" ] [ Html.text "Cancel" ]
+                     else
+                        Nothing
+                    )
+                , Html.div [ class "form-body" ]
+                    [ Html.viewIf (not editing && TableSpec.getTag spec /= TagProjects) modeSelector
+                    , Html.viewIf (not editing && table.addMode == AddFromOtherProject && TableSpec.getTag spec /= TagProjects) <| Html.Lazy.lazy viewSelectExisting table.selectExistingSteps
+                    , Html.viewIf (not editing && table.addMode == AddNew || editing) nameInput
+                    , Html.viewIf (not editing && table.addMode == AddNew || editing) noteInput
+                    , Html.viewIf ((not editing && table.addMode == AddNew || editing) && not (List.isEmpty extraFields)) <|
+                        Html.div [ class "form-group" ] extraFields
+                    , extraSection
+                    , Html.div [ class "form-actions" ]
+                        [ Html.button [ id "save-button", Events.onClick (TableSpec.getUpsertRecord spec), class "btn", disabled table.isUpdating ]
+                            [ Html.text "Save" ]
+                        , Html.button [ Events.onClick cancelAction, class "btn" ] [ Html.text "Cancel" ]
+                        ]
                     ]
+                , Html.viewIf savingInFlight <|
+                    Html.div [ class "loading-overlay" ] [ iconCustom True "progress_activity" [ class "loading-icon" ] ]
                 ]
             ]
         ]
@@ -2212,18 +2252,6 @@ dirButton isOpen dirPath recordId =
         (Actions.toggleOutputEntry recordId Nothing dirPath |> Flow.map (always ()))
 
 
-dirCodeButton : Bool -> List String -> Int -> Html (Flow Model ())
-dirCodeButton isOpen dirPath recordId =
-    viewIconButtonWithTooltip
-        (if isOpen then
-            "folder_open"
-
-         else
-            "folder_code"
-        )
-        True
-        "Browse source files"
-        (Actions.toggleSrcEntry recordId Nothing dirPath |> Flow.map (always ()))
 
 
 recordAutocompleteStateKey : String -> String -> String -> List StepArgValue -> Int -> StepArgValue -> String

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -534,6 +534,23 @@ body {
   overflow-wrap: anywhere;
 }
 
+.src-file-change-status {
+  flex: 0 0 auto;
+  padding: 0 var(--spacing-xs);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  background: var(--state-warning-outline);
+  border-radius: 999px;
+
+  &.is-new {
+    background: var(--state-success-outline);
+  }
+
+  &.is-deleted {
+    background: var(--state-danger-outline);
+  }
+}
+
 .file-actions {
   display: flex;
   gap: var(--spacing-xs);


### PR DESCRIPTION
<img width="983" height="593" alt="image" src="https://github.com/user-attachments/assets/0932ec34-425e-4d72-9763-3394238f6a95" />

Source files are now browsed and edited inside the step edit form. Changes are staged as they go: Changed (yellow), New (green), Deleted (red). The form's Save writes all staged changes and then saves the step; Cancel discards them. While saving, the row shows a spinner and a reopened form is covered by a loading overlay. The old source-file browser and its row action that opened it are removed.

Closes #122 